### PR TITLE
Fixed NPE on pressing search for Android 5.0.1

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -356,8 +356,8 @@
     <style name="Widget.Plaid.SearchView" parent="android:style/Widget.Material.SearchView">
         <item name="android:searchIcon">@null</item>
         <item name="android:searchHintIcon">@null</item>
-        <item name="android:queryBackground">@null</item>
-        <item name="android:submitBackground">@null</item>
+        <item name="android:queryBackground">@android:color/transparent</item>
+        <item name="android:submitBackground">@android:color/transparent</item>
     </style>
 
     <style name="Widget.Plaid.DribbleShotAction" parent="@android:style/Widget.Material.Button">


### PR DESCRIPTION
Changed style values in order to avoid NPE in API21
fixes #6

Well, I haven't seen any difference if I've commented them out, but there was surely a point to setting them to @null. Turning them now to transparent should give the same effect and causes no crashes.