### PR TITLE
fix opening app the from recents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
         <activity
             android:name=".ui.HomeActivity"
             android:label="@string/app_name"
-            android:theme="@style/Plaid.Home" />
+            android:theme="@style/Plaid.Home"
+            android:exported="true" />
 
         <!-- use an alias in case we want to change the launch activity later without breaking
              homescreen shortcuts.  Note must be defined after the targetActivity -->


### PR DESCRIPTION
When someone leaved the app using the back button and then tries to open the app from recents, Android shows a Toast saying "Could not start the Plaid". This is caused by the acitivity-alias and fixed by exporting the targetActivity.
https://code.google.com/p/android/issues/detail?id=82185

closes #12 