### PR TITLE
Fixed loading indicator shown on back press issue.

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/DribbbleLogin.java
+++ b/app/src/main/java/io/plaidapp/ui/DribbbleLogin.java
@@ -97,7 +97,16 @@ public class DribbbleLogin extends Activity {
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        setIntent(intent);
         checkAuthCallback(intent);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus && getIntent().getData() == null && loading.getVisibility() == View.VISIBLE) {
+            showLogin();
+        }
     }
 
     public void doLogin(View view) {


### PR DESCRIPTION
Goto **Dribble Shot -> Like/Comment on the shot -> press "Log In to  Dribble" -> Browser is loaded -> Now press back button.**

Empty Progress indicator is shown like below:
![plaid_dribble](https://cloud.githubusercontent.com/assets/250998/11104203/252f32bc-88ed-11e5-806d-e035a93ec26f.png)

**Fix:**
When user presses the back button from browser now the login dialog is shown. 