### PR TITLE
Update gradle build tools to 2.0.0-beta4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta4'
     }
 
 }


### PR DESCRIPTION
Update build tools to latest version (2.0.0-beta4) with some performance improvements especially related to the Instant Run feature. (http://tools.android.com/tech-docs/new-build-system)