### PR TITLE
Fix edge case for bottom sheet not being dismissed

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/widget/BottomSheet.java
+++ b/app/src/main/java/io/plaidapp/ui/widget/BottomSheet.java
@@ -241,7 +241,12 @@ public class BottomSheet extends FrameLayout {
 
     private void animateSettle(int initialOffset, final int targetOffset, long duration) {
         if (settling) return;
-        if (sheetOffsetHelper.getTopAndBottomOffset() == targetOffset) return;
+        if (sheetOffsetHelper.getTopAndBottomOffset() == targetOffset) {
+          if (targetOffset >= dismissOffset) {
+              dispatchDismissCallback();
+          }
+          return;
+        }
 
         settling = true;
         final ObjectAnimator settleAnim = ObjectAnimator.ofInt(sheetOffsetHelper,


### PR DESCRIPTION
If you drag the bottom sheet all the way to the dismiss offset, the
callback was not being notified.

This can be reproduced on master fairly reliably by keeping your finger down and dragging through the nav bar and onto the bezel.