### PR TITLE
Fix FabTransform circular reveal calculation

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/transitions/FabTransform.java
+++ b/app/src/main/java/io/plaidapp/ui/transitions/FabTransform.java
@@ -198,14 +198,14 @@ public class FabTransform extends Transition {
                     view.getWidth() / 2,
                     view.getHeight() / 2,
                     startBounds.width() / 2,
-                    (float) Math.hypot(endBounds.width() / 2, endBounds.width() / 2));
+                    (float) Math.hypot(endBounds.width() / 2, endBounds.height() / 2));
             circularReveal.setInterpolator(
                     AnimUtils.getFastOutLinearInInterpolator(sceneRoot.getContext()));
         } else {
             circularReveal = ViewAnimationUtils.createCircularReveal(view,
                     view.getWidth() / 2,
                     view.getHeight() / 2,
-                    (float) Math.hypot(startBounds.width() / 2, startBounds.width() / 2),
+                    (float) Math.hypot(startBounds.width() / 2, startBounds.height() / 2),
                     endBounds.width() / 2);
             circularReveal.setInterpolator(
                     AnimUtils.getLinearOutSlowInInterpolator(sceneRoot.getContext()));


### PR DESCRIPTION
This isn't really noticable at high transition speed, but slowed down you see that the transition from the fab to an activity cuts off after approx. 75% of the animation and just jumps to the non-clipped activity. With this fix the end radius gets calculated correctly. Same for the reversed transition.