### PR TITLE
Eneim/fix line spacing add

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/widget/CollapsingTitleLayout.java
+++ b/app/src/main/java/io/plaidapp/ui/widget/CollapsingTitleLayout.java
@@ -235,7 +235,8 @@ public class CollapsingTitleLayout extends FrameLayout {
         int fontHeight = Math.abs(fm.ascent - fm.descent) + fm.leading;
         final int baselineAlignedLineHeight =
                 (int) (fourDip * (float) Math.ceil(lineHeightHint / fourDip));
-        final int lineSpacingAdd = baselineAlignedLineHeight - fontHeight;
+        // Addition line spacing to match desired line height. Should be non-negative.
+        final int lineSpacingAdd = Math.max(0, baselineAlignedLineHeight - fontHeight);
 
         // now create the layout with our desired insets & line height
         createLayout(width, lineSpacingAdd);


### PR DESCRIPTION
When I use your CollapsingTextLayout without a pre-defined styling, the multiline title's lines are overlap each other. It turns out that when you have no ```lineHeightHint``` set, the ```lineSpacingAdd``` will be negative (to be correct: it is equal to  the **fourDip rounded** version of ```0 - fontHeight```). IMO, to be having multi line title every time, that value should be at least zero (so default line height is exactly the font height). So I add a constraint for it.

Please check out and give your idea.