### PR TITLE
Fix of show accounts dropdown when transition is ended by backpressed issue #117

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/DesignerNewsLogin.java
+++ b/app/src/main/java/io/plaidapp/ui/DesignerNewsLogin.java
@@ -110,6 +110,7 @@ public class DesignerNewsLogin extends Activity {
             getWindow().getSharedElementEnterTransition().addListener(new TransitionUtils.TransitionListenerAdapter() {
                 @Override
                 public void onTransitionEnd(Transition transition) {
+                    getWindow().getSharedElementEnterTransition().removeListener(this);
                     finishSetup();
                 }
             });


### PR DESCRIPTION
emove onTransitionEnd listener after it is called to avoid username.showDropDown() be called on end transition by backpressed