### PR TITLE
Mark app with large heap

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Plaid">
+        android:theme="@style/Plaid"
+        android:largeHeap="true">
 
         <activity
             android:name=".ui.HomeActivity"


### PR DESCRIPTION
Due to the fact this app is using images, using large heap gives it a bigger heap size, minimising OOMs (e.g. #22). It won't fix all OOMs but will help. 
https://developer.android.com/guide/topics/manifest/application-element.html#largeHeap
