### PR TITLE
Removed synthetic accessors from AboutActivity

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/AboutActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/AboutActivity.java
@@ -191,7 +191,7 @@ public class AboutActivity extends Activity {
 
         private static final int VIEW_TYPE_INTRO = 0;
         private static final int VIEW_TYPE_LIBRARY = 1;
-        private static final Library[] libs = {
+        static final Library[] libs = {
                 new Library("Android support libraries",
                         "The Android support libraries offer a number of features that are not built into the framework.",
                         "https://developer.android.com/topic/libraries/support-library",
@@ -229,7 +229,7 @@ public class AboutActivity extends Activity {
                         false) };
 
         private final CircleTransform circleCrop;
-        private final Activity host;
+        final Activity host;
 
         LibraryAdapter(Activity host) {
             this.host = host;


### PR DESCRIPTION
@nickbutcher please review. I watched the presentation,  enabled the InteliJ option and fixed the AboutActivity because I previously introduced `Activity host`