### PR TITLE
Fix content hover issue in Dribbble post.

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/DribbbleShot.java
+++ b/app/src/main/java/io/plaidapp/ui/DribbbleShot.java
@@ -560,6 +560,13 @@ public class DribbbleShot extends Activity {
             // kick off an anim (via animated state list) on the post button. see
             // @drawable/ic_add_comment
             postComment.setActivated(hasFocus);
+
+            // prevent content hovering over image when not pinned.
+            if(hasFocus) {
+                imageView.bringToFront();
+                imageView.setOffset(-imageView.getHeight());
+                imageView.setImmediatePin(true);
+            }
         }
     };
 


### PR DESCRIPTION
When you'd open a Dribbble post where the height was smaller than ( screenHeight - minOffset ), the dribbble_shot_description would hover the image, and improperly place the FAB where you can't post your comment.

https://goo.gl/photos/GqevB37SrKm9ogzD6

These changes fix that:

https://goo.gl/photos/R9UeT8LkP3USN2eS7