### PR TITLE
Upgrade to Retrofit 2.2, fix unchecked call warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ repositories {
 }
 
 ext.supportLibVersion = '25.1.0'
+ext.retrofit2Version = '2.2.0'
 
 dependencies {
     compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
@@ -83,8 +84,8 @@ dependencies {
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.jakewharton:butterknife:8.4.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.4.0'
-    compile 'com.squareup.retrofit2:retrofit:2.1.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
+    compile "com.squareup.retrofit2:retrofit:${retrofit2Version}"
+    compile "com.squareup.retrofit2:converter-gson:${retrofit2Version}"
     compile 'com.squareup.okhttp3:okhttp:3.4.2'
     compile 'org.jsoup:jsoup:1.10.1'
     compile project(':bypass')

--- a/app/src/main/java/io/plaidapp/data/api/dribbble/FollowersDataManager.java
+++ b/app/src/main/java/io/plaidapp/data/api/dribbble/FollowersDataManager.java
@@ -32,7 +32,7 @@ import retrofit2.Response;
 public abstract class FollowersDataManager extends PaginatedDataManager<List<Follow>> {
 
     private final long playerId;
-    private Call userFollowersCall;
+    private Call<List<Follow>> userFollowersCall;
 
     public FollowersDataManager(Context context, long playerId) {
         super(context);

--- a/app/src/main/java/io/plaidapp/data/api/dribbble/PlayerShotsDataManager.java
+++ b/app/src/main/java/io/plaidapp/data/api/dribbble/PlayerShotsDataManager.java
@@ -38,7 +38,7 @@ public abstract class PlayerShotsDataManager extends PaginatedDataManager<List<S
 
     private final long userId;
     private final boolean isTeam;
-    private Call loadShotsCall;
+    private Call<List<Shot>> loadShotsCall;
 
     public PlayerShotsDataManager(Context context, User player) {
         super(context);

--- a/app/src/main/java/io/plaidapp/data/api/dribbble/ShotLikesDataManager.java
+++ b/app/src/main/java/io/plaidapp/data/api/dribbble/ShotLikesDataManager.java
@@ -32,7 +32,7 @@ import retrofit2.Response;
 public abstract class ShotLikesDataManager extends PaginatedDataManager<List<Like>> {
 
     private final long shotId;
-    private Call shotLikesCall;
+    private Call<List<Like>> shotLikesCall;
 
     public ShotLikesDataManager(Context context, long shotId) {
         super(context);

--- a/app/src/main/java/io/plaidapp/data/api/dribbble/TeamMembersDataManager.java
+++ b/app/src/main/java/io/plaidapp/data/api/dribbble/TeamMembersDataManager.java
@@ -32,7 +32,7 @@ import retrofit2.Response;
 public abstract class TeamMembersDataManager extends PaginatedDataManager<List<User>> {
 
     private final String teamName;
-    private Call teamMembersCall;
+    private Call<List<User>> teamMembersCall;
 
     public TeamMembersDataManager(Context context, String teamName) {
         super(context);


### PR DESCRIPTION
Upgrade to [Retrofit 2.2](https://github.com/square/retrofit/blob/master/CHANGELOG.md#version-220-2017-02-21) to pick up bug fixes etc.

Fix some warnings resulting from use of raw `Call` type.