### PR TITLE
Adds home screen search widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -154,6 +154,16 @@
                 android:resource="@xml/glide_disk_cache_path" />
         </provider>
 
+        <receiver android:name=".ui.widget.SearchAppWidget" android:label="@string/search_hint">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/search_widget"
+            />
+        </receiver>
+
         <!-- Glide configurations for image loading -->
         <meta-data
             android:name="io.plaidapp.util.glide.GlideConfiguration"

--- a/app/src/main/java/io/plaidapp/ui/SearchActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/SearchActivity.java
@@ -69,6 +69,7 @@ public class SearchActivity extends Activity {
     public static final String EXTRA_QUERY = "EXTRA_QUERY";
     public static final String EXTRA_SAVE_DRIBBBLE = "EXTRA_SAVE_DRIBBBLE";
     public static final String EXTRA_SAVE_DESIGNER_NEWS = "EXTRA_SAVE_DESIGNER_NEWS";
+    public static final String EXTRA_DISABLE_SAVE = "EXTRA_DISABLE_SAVE";
     public static final int RESULT_CODE_SAVE = 7;
 
     @BindView(R.id.searchback) ImageButton searchBack;
@@ -99,7 +100,7 @@ public class SearchActivity extends Activity {
         setContentView(R.layout.activity_search);
         ButterKnife.bind(this);
         setupSearchView();
-
+        final Intent intent = getIntent();
         dataManager = new SearchDataManager(this) {
             @Override
             public void onDataLoaded(List<? extends PlaidItem> data) {
@@ -109,7 +110,8 @@ public class SearchActivity extends Activity {
                                 getTransition(R.transition.search_show_results));
                         progress.setVisibility(View.GONE);
                         results.setVisibility(View.VISIBLE);
-                        fab.setVisibility(View.VISIBLE);
+                        fab.setVisibility(intent.hasExtra(EXTRA_DISABLE_SAVE) && intent.getBooleanExtra(EXTRA_DISABLE_SAVE, false) ?
+                                View.GONE : View.VISIBLE);
                     }
                     adapter.addAndResort(data);
                 } else {

--- a/app/src/main/java/io/plaidapp/ui/widget/SearchAppWidget.java
+++ b/app/src/main/java/io/plaidapp/ui/widget/SearchAppWidget.java
@@ -1,0 +1,33 @@
+package io.plaidapp.ui.widget;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.RemoteViews;
+
+import io.plaidapp.R;
+import io.plaidapp.ui.SearchActivity;
+
+public class SearchAppWidget extends AppWidgetProvider {
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        PendingIntent pendingIntent = createPendingIntent(context);
+        for (int i = 0, l = appWidgetIds.length; i < l; i++) {
+            int appWidgetId = appWidgetIds[i];
+            final RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.search_widget);
+            views.setOnClickPendingIntent(R.id.search_view, pendingIntent);
+            appWidgetManager.updateAppWidget(appWidgetId, views);
+        }
+    }
+
+    private PendingIntent createPendingIntent(Context context) {
+        final Intent intent = new Intent(context, SearchActivity.class);
+        intent.putExtra(SearchActivity.EXTRA_DISABLE_SAVE, true);
+        intent.setAction(Intent.ACTION_VIEW);
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+}

--- a/app/src/main/res/drawable/ic_shortcut_post.xml
+++ b/app/src/main/res/drawable/ic_shortcut_post.xml
@@ -17,8 +17,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="@dimen/min_touch_target"
+    android:height="@dimen/min_touch_target"
     android:viewportWidth="48"
     android:viewportHeight="48">
 

--- a/app/src/main/res/drawable/ic_shortcut_search.xml
+++ b/app/src/main/res/drawable/ic_shortcut_search.xml
@@ -17,8 +17,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="@dimen/min_touch_target"
+    android:height="@dimen/min_touch_target"
     android:viewportWidth="48"
     android:viewportHeight="48">
 

--- a/app/src/main/res/layout/search_widget.xml
+++ b/app/src/main/res/layout/search_widget.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/search_view"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:drawableTop="@drawable/ic_shortcut_search"
+    android:drawablePadding="@dimen/spacing_micro"
+    android:gravity="center"
+    android:textColor="@android:color/white"
+    android:text="@string/search"/>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -38,7 +38,7 @@
     <!-- text input layout seems to add 4dp of extra padding. The following account for this -->
     <dimen name="padding_normal_til">12dp</dimen>
     <dimen name="til_margin_fix">-4dp</dimen>
-
+    <dimen name="min_touch_target">48dp</dimen>
 
     <!-- dialogs -->
     <dimen name="padding_dialog">24dp</dimen>

--- a/app/src/main/res/xml/search_widget.xml
+++ b/app/src/main/res/xml/search_widget.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/search_widget"
+    android:minWidth="@dimen/min_touch_target"
+    android:minHeight="@dimen/min_touch_target"
+    android:resizeMode="none"
+    android:widgetCategory="home_screen"
+    android:previewImage="@drawable/ic_shortcut_search"/>
+


### PR DESCRIPTION
Plaid already supports shortcuts for search
and for creating a designer story  but it is
only available on Android 7.1
Adding a Widget on the home screen is a good
enough backport for older Android versions

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/802308/24326945/30161ed8-1191-11e7-9b29-78a5ece3d640.gif)
