### PR TITLE
Adds shortcut widget for searching

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,6 +136,18 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".ui.SearchShortcutConfigureActivity"
+            android:theme="@style/Plaid.Translucent"
+            android:icon="@drawable/ic_shortcut_search"
+            android:label="@string/search"
+            android:excludeFromRecents="true"
+            android:taskAffinity="">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".data.api.designernews.PostStoryService"
             android:exported="false" />

--- a/app/src/main/java/io/plaidapp/ui/SearchActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/SearchActivity.java
@@ -70,6 +70,7 @@ public class SearchActivity extends Activity {
     public static final String EXTRA_SAVE_DRIBBBLE = "EXTRA_SAVE_DRIBBBLE";
     public static final String EXTRA_SAVE_DESIGNER_NEWS = "EXTRA_SAVE_DESIGNER_NEWS";
     public static final int RESULT_CODE_SAVE = 7;
+    public static final String EXTRA_DISABLE_SAVE = "EXTRA_DISABLE_SAVE";
 
     @BindView(R.id.searchback) ImageButton searchBack;
     @BindView(R.id.searchback_container) ViewGroup searchBackContainer;
@@ -99,7 +100,7 @@ public class SearchActivity extends Activity {
         setContentView(R.layout.activity_search);
         ButterKnife.bind(this);
         setupSearchView();
-
+        final Intent intent = getIntent();
         dataManager = new SearchDataManager(this) {
             @Override
             public void onDataLoaded(List<? extends PlaidItem> data) {
@@ -109,7 +110,8 @@ public class SearchActivity extends Activity {
                                 getTransition(R.transition.search_show_results));
                         progress.setVisibility(View.GONE);
                         results.setVisibility(View.VISIBLE);
-                        fab.setVisibility(View.VISIBLE);
+                        fab.setVisibility(intent.hasExtra(EXTRA_DISABLE_SAVE) && intent.getBooleanExtra(EXTRA_DISABLE_SAVE, false) ?
+                                View.GONE : View.VISIBLE);
                     }
                     adapter.addAndResort(data);
                 } else {

--- a/app/src/main/java/io/plaidapp/ui/SearchShortcutConfigureActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/SearchShortcutConfigureActivity.java
@@ -1,0 +1,27 @@
+package io.plaidapp.ui;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+import io.plaidapp.R;
+
+public class SearchShortcutConfigureActivity extends Activity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent launchIntent = new Intent(this, SearchActivity.class);
+        launchIntent.putExtra(SearchActivity.EXTRA_DISABLE_SAVE, true);
+
+        Intent.ShortcutIconResource icon = Intent.ShortcutIconResource.fromContext(this, R.drawable.ic_shortcut_search);
+        Intent intent = new Intent();
+        intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, getString(R.string.search));
+        intent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, icon);
+        intent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, launchIntent);
+
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+}

--- a/app/src/main/res/drawable/ic_shortcut_post.xml
+++ b/app/src/main/res/drawable/ic_shortcut_post.xml
@@ -17,8 +17,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="@dimen/min_touch_target"
+    android:height="@dimen/min_touch_target"
     android:viewportWidth="48"
     android:viewportHeight="48">
 

--- a/app/src/main/res/drawable/ic_shortcut_search.xml
+++ b/app/src/main/res/drawable/ic_shortcut_search.xml
@@ -17,8 +17,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="48dp"
-    android:height="48dp"
+    android:width="@dimen/min_touch_target"
+    android:height="@dimen/min_touch_target"
     android:viewportWidth="48"
     android:viewportHeight="48">
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -38,7 +38,7 @@
     <!-- text input layout seems to add 4dp of extra padding. The following account for this -->
     <dimen name="padding_normal_til">12dp</dimen>
     <dimen name="til_margin_fix">-4dp</dimen>
-
+    <dimen name="min_touch_target">48dp</dimen>
 
     <!-- dialogs -->
     <dimen name="padding_dialog">24dp</dimen>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -26,7 +26,11 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="io.plaidapp.ui.SearchActivity"
-            android:targetPackage="io.plaidapp" />
+            android:targetPackage="io.plaidapp">
+            <extra
+                android:name="EXTRA_DISABLE_SAVE"
+                android:value="true"/>
+        </intent>
     </shortcut>
 
 </shortcuts>


### PR DESCRIPTION
Plaid already supports shortcuts for search
and for creating a designer story  but it is
only available on Android 7.1

Adding a shortcut widget on the home screen
is a good enough backport for older versions

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/802308/24332963/c099095c-121d-11e7-8907-9369c5919e49.gif)
