### PR TITLE
Fixed warning in RecyclerView during infinite scrolling

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/HomeActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/HomeActivity.java
@@ -97,7 +97,6 @@ import io.plaidapp.ui.transitions.MorphTransform;
 import io.plaidapp.util.AnimUtils;
 import io.plaidapp.util.DrawableUtils;
 import io.plaidapp.util.ViewUtils;
-import io.plaidapp.util.glide.GlideApp;
 
 
 public class HomeActivity extends Activity {
@@ -186,11 +185,7 @@ public class HomeActivity extends Activity {
         grid.addOnScrollListener(new InfiniteScrollListener(layoutManager, dataManager) {
             @Override
             public void onLoadMore() {
-                grid.post(new Runnable() {
-                    @Override public void run() {
-                        dataManager.loadAllDataSources();
-                    }
-                });
+                dataManager.loadAllDataSources();
             }
         });
         grid.setHasFixedSize(true);

--- a/app/src/main/java/io/plaidapp/ui/HomeActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/HomeActivity.java
@@ -186,7 +186,11 @@ public class HomeActivity extends Activity {
         grid.addOnScrollListener(new InfiniteScrollListener(layoutManager, dataManager) {
             @Override
             public void onLoadMore() {
-                dataManager.loadAllDataSources();
+                grid.post(new Runnable() {
+                    @Override public void run() {
+                        dataManager.loadAllDataSources();
+                    }
+                });
             }
         });
         grid.setHasFixedSize(true);

--- a/app/src/main/java/io/plaidapp/ui/recyclerview/InfiniteScrollListener.java
+++ b/app/src/main/java/io/plaidapp/ui/recyclerview/InfiniteScrollListener.java
@@ -51,7 +51,11 @@ public abstract class InfiniteScrollListener extends RecyclerView.OnScrollListen
         final int firstVisibleItem = layoutManager.findFirstVisibleItemPosition();
 
         if ((totalItemCount - visibleItemCount) <= (firstVisibleItem + VISIBLE_THRESHOLD)) {
-            onLoadMore();
+            recyclerView.post(new Runnable() {
+                @Override public void run() {
+                    onLoadMore();
+                }
+            });
         }
     }
 

--- a/app/src/main/java/io/plaidapp/ui/recyclerview/InfiniteScrollListener.java
+++ b/app/src/main/java/io/plaidapp/ui/recyclerview/InfiniteScrollListener.java
@@ -34,6 +34,12 @@ public abstract class InfiniteScrollListener extends RecyclerView.OnScrollListen
 
     private final LinearLayoutManager layoutManager;
     private final DataLoadingSubject dataLoading;
+    private final Runnable loadMoreRunnable = new Runnable() {
+        @Override
+        public void run() {
+            onLoadMore();
+        }
+    };
 
     public InfiniteScrollListener(@NonNull LinearLayoutManager layoutManager,
                                   @NonNull DataLoadingSubject dataLoading) {
@@ -51,11 +57,7 @@ public abstract class InfiniteScrollListener extends RecyclerView.OnScrollListen
         final int firstVisibleItem = layoutManager.findFirstVisibleItemPosition();
 
         if ((totalItemCount - visibleItemCount) <= (firstVisibleItem + VISIBLE_THRESHOLD)) {
-            recyclerView.post(new Runnable() {
-                @Override public void run() {
-                    onLoadMore();
-                }
-            });
+            recyclerView.post(loadMoreRunnable);
         }
     }
 


### PR DESCRIPTION
It's a fix for issue #224 as proposed [here](https://guides.codepath.com/android/Endless-Scrolling-with-AdapterViews-and-RecyclerView#troubleshooting).