### PR TITLE
Fix ink page indicator null pointer exception

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/widget/InkPageIndicator.java
+++ b/app/src/main/java/io/plaidapp/ui/widget/InkPageIndicator.java
@@ -561,7 +561,8 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
     }
 
     private void setSelectedPage(int now) {
-        if (now == currentPage) return;
+        // Check for null array
+        if (now == currentPage || dotCenterX == null) return;
 
         pageChanging = true;
         previousPage = currentPage;


### PR DESCRIPTION
In setSelectedPage(int) method, dotCenterX might be null on various
configuration changes like entering or exiting the multi-window mode.
This issue can be replicated by following the steps below:
1. Open about section within the Plaid app.
2. Navigate to the second page, it will not appear on the first page.
3. Try to enter in the multi-window mode and then resize the window
by draging the handle. The app will crash with null pointer exception.

This issue has been fixed and can be tested in the app below:
[Rotation - Orientation Manager](https://play.google.com/store/apps/details?id=com.pranavpandey.rotation)