### PR TITLE
Set app version name in build script instead of git tag.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,13 +27,13 @@ android {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
         versionCode rootProject.gitCommitCount
-        versionName rootProject.gitTag
-        archivesBaseName = "plaid"
+        versionName = '1.0.2'
+        archivesBaseName = 'plaid'
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
 
-        resConfig "en"
-        buildConfigField "String", "GIT_SHA", "\"${gitSha}\""
+        resConfig 'en'
+        buildConfigField 'String', 'GIT_SHA', "\"${gitSha}\""
          manifestPlaceholders += [
                  crashlyticsEnabled: false
          ]
@@ -41,8 +41,7 @@ android {
     buildTypes {
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
-                    'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             manifestPlaceholders += [crashlyticsEnabled: true]
         }
     }
@@ -55,8 +54,8 @@ android {
 
 repositories {
     google()
-    jcenter()
     maven { url 'https://maven.fabric.io/public' }
+    jcenter()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -62,13 +62,12 @@ buildscript {
 }
 
 plugins {
-    id "com.diffplug.gradle.spotless" version "3.13.0"
+    id 'com.diffplug.gradle.spotless' version '3.13.0'
 }
 
 ext {
     // query git for the SHA, Tag and commit count. Use these to automate versioning.
     gitSha = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
-    gitTag = 'git describe --tags'.execute([], project.rootDir).text.trim()
     gitCommitCount = 100 +
             Integer.parseInt('git rev-list --count HEAD'.execute([], project.rootDir).text.trim())
 }
@@ -77,7 +76,7 @@ subprojects {
     apply plugin: 'com.diffplug.gradle.spotless'
     spotless {
         kotlin {
-            target "**/*.kt"
+            target '**/*.kt'
             ktlint(versions.ktlint)
             licenseHeaderFile project.rootProject.file('scripts/copyright.kt')
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,22 +27,22 @@ android {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
 
-        buildConfigField "String", "DESIGNER_NEWS_CLIENT_ID", "\"${designer_news_client_id}\""
-        buildConfigField "boolean", "DESIGNER_NEWS_V2", "true" // May be overridden by a build type.
+        buildConfigField 'String', 'DESIGNER_NEWS_CLIENT_ID', "\"${designer_news_client_id}\""
+        buildConfigField 'boolean', 'DESIGNER_NEWS_V2', 'true' // May be overridden by a build type.
 
-        buildConfigField "String", "DESIGNER_NEWS_CLIENT_ID", "\"${designer_news_client_id}\""
-        buildConfigField "String",
-                "DESIGNER_NEWS_CLIENT_SECRET", "\"${designer_news_client_secret}\""
+        buildConfigField 'String', 'DESIGNER_NEWS_CLIENT_ID', "\"${designer_news_client_id}\""
+        buildConfigField 'String',
+                'DESIGNER_NEWS_CLIENT_SECRET', "\"${designer_news_client_secret}\""
 
-        buildConfigField "String",
-                "PRODUCT_HUNT_DEVELOPER_TOKEN", "\"${product_hunt_developer_token}\""
+        buildConfigField 'String',
+                'PRODUCT_HUNT_DEVELOPER_TOKEN', "\"${product_hunt_developer_token}\""
     }
 
     buildTypes {
         release {
-            buildConfigField "boolean", "DESIGNER_NEWS_V2", "false"
+            buildConfigField 'boolean', 'DESIGNER_NEWS_V2', 'false'
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -96,9 +96,10 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"
     androidTestImplementation "com.squareup.retrofit2:retrofit-mock:${versions.retrofit}"
 }
+
 kotlin {
     experimental {
-        coroutines "enable"
+        coroutines 'enable'
     }
 }
 

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-        resConfig "en"
+        resConfig 'en'
     }
     buildTypes {
         release {

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -23,8 +23,8 @@ android {
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-        def filesAuthorityValue = names.applicationId + ".shareprovider"
-        buildConfigField "String", "FILES_AUTHORITY", "\"${filesAuthorityValue}\""
+        def filesAuthorityValue = names.applicationId + '.shareprovider'
+        buildConfigField 'String', 'FILES_AUTHORITY', "\"${filesAuthorityValue}\""
         manifestPlaceholders = [filesAuthority: filesAuthorityValue]
     }
 

--- a/third_party/bypass/build.gradle
+++ b/third_party/bypass/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 23
         targetSdkVersion versions.targetSdk
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
     buildTypes {
         release {


### PR DESCRIPTION
This is a step toward enabling releasing from CI. Version code still
derived from git commit count.