### PR TITLE
Fix build config debug suffix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion versions.compileSdk
 
     defaultConfig {
-        applicationId names.applicationId
+        applicationId 'io.plaidapp'
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
         versionCode rootProject.gitCommitCount
@@ -41,7 +41,6 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix '.debug'
-            rootProject.ext.names.applicationId += '.debug'
             versionNameSuffix '-DEBUG'
         }
         release {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,7 +36,7 @@ android {
         buildConfigField 'String',
                 'PRODUCT_HUNT_DEVELOPER_TOKEN', "\"${product_hunt_developer_token}\""
 
-        buildConfigField 'String', 'PACKAGE', "\"${names.applicationId}\""
+        buildConfigField 'String', 'PACKAGE', "\"${applicationId}\""
     }
 
     buildTypes {

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         minSdkVersion versions.minSdk
         targetSdkVersion versions.targetSdk
-        def filesAuthorityValue = names.applicationId + '.shareprovider'
+        def filesAuthorityValue = applicationId + '.shareprovider'
         buildConfigField 'String', 'FILES_AUTHORITY', "\"${filesAuthorityValue}\""
         manifestPlaceholders = [filesAuthority: filesAuthorityValue]
     }


### PR DESCRIPTION
Build config was picking up the .debug suffix for release builds. Now it's not any more.