### PR TITLE
Remove build config suffixing for now

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,11 +39,6 @@ android {
         ]
     }
     buildTypes {
-        debug {
-            applicationIdSuffix '.debug'
-            rootProject.ext.names.applicationId += '.debug'
-            versionNameSuffix '-DEBUG'
-        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,7 +36,6 @@ android {
         buildConfigField 'String',
                 'PRODUCT_HUNT_DEVELOPER_TOKEN', "\"${product_hunt_developer_token}\""
 
-        buildConfigField 'String', 'PACKAGE', "\"${names.applicationId}\""
     }
 
     buildTypes {

--- a/core/src/main/java/io/plaidapp/core/util/ActivityHelper.kt
+++ b/core/src/main/java/io/plaidapp/core/util/ActivityHelper.kt
@@ -24,9 +24,7 @@ import android.content.Intent
 import android.support.customtabs.CustomTabsIntent
 import android.support.customtabs.CustomTabsSession
 import android.support.v4.content.ContextCompat
-import io.plaidapp.core.BuildConfig
 import io.plaidapp.core.R
-import io.plaidapp.core.designernews.data.stories.model.Story
 import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
 
 /**
@@ -40,7 +38,7 @@ private const val PACKAGE_NAME = "io.plaidapp"
  */
 fun intentTo(addressableActivity: AddressableActivity): Intent {
     return Intent(Intent.ACTION_VIEW).setClassName(
-            BuildConfig.PACKAGE,
+            PACKAGE_NAME,
             addressableActivity.className)
 }
 


### PR DESCRIPTION
The current setup caused too much overhead for having two versions of the app installed at the same time. This PR removes the `.debug` package suffix and BuildConfig field for package.