### PR TITLE
Optimize flattening CommentWithReplies

### DIFF
--- a/core/src/main/java/io/plaidapp/core/designernews/domain/model/CommentWithReplies.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/domain/model/CommentWithReplies.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.core.designernews.domain.model
 
 import io.plaidapp.core.designernews.data.users.model.User
-import java.util.Date
+import java.util.*
 
 fun CommentWithReplies.toComment(
     user: User?
@@ -47,4 +47,11 @@ data class CommentWithReplies(
     val userId: Long,
     val storyId: Long,
     val replies: List<CommentWithReplies> = emptyList()
-)
+) {
+    /**
+     * @return a flattened, recursive sequence of this [CommentWithReplies] and all its nested
+     * [replies].
+     */
+    val flattenWithReplies: Sequence<CommentWithReplies>
+        get() = sequenceOf(this) + replies.asSequence().flatMap(CommentWithReplies::flattenWithReplies)
+}

--- a/core/src/main/java/io/plaidapp/core/designernews/domain/model/CommentWithReplies.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/domain/model/CommentWithReplies.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.core.designernews.domain.model
 
 import io.plaidapp.core.designernews.data.users.model.User
-import java.util.*
+import java.util.Date
 
 fun CommentWithReplies.toComment(
     user: User?

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/CommentsWithRepliesAndUsersUseCase.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/CommentsWithRepliesAndUsersUseCase.kt
@@ -64,23 +64,10 @@ class CommentsWithRepliesAndUsersUseCase(
         commentsWithReplies: List<CommentWithReplies>,
         users: Set<User>
     ): List<Comment> {
-        val userMapping = users.map { it.id to it }.toMap()
-        val comments = mutableListOf<Comment>()
-        unnestCommentsWithReplies(commentsWithReplies, userMapping, comments)
-        return comments
-    }
-
-    private fun unnestCommentsWithReplies(
-        commentsWithReplies: List<CommentWithReplies>,
-        users: Map<Long, User>,
-        comments: MutableList<Comment>
-    ) {
-        commentsWithReplies.forEach {
-            val user = users[it.userId]
-            comments.add(it.toComment(user))
-            if (it.replies.isNotEmpty()) {
-                unnestCommentsWithReplies(it.replies, users, comments)
-            }
-        }
+        val userMapping = users.associateBy(User::id)
+        return commentsWithReplies.asSequence()
+                .flatMap(CommentWithReplies::flattenWithReplies)
+                .map { it.toComment(userMapping[it.userId]) }
+                .toList()
     }
 }


### PR DESCRIPTION
This tweaks flattening `CommentWithReplies` with a more optimized version via recursive sequence-generating `flattenWithReplies` property. This makes the entire flattening process a single iteration with no mutable intermediate state. 

Also opportunistically changed

```kotlin
val userMapping = users.map { it.id to it }.toMap()
```

to the more idiomatic (but functionally the same sans one iteration)

```kotlin
val userMapping = users.associateBy(User::id)
```