### PR TITLE
Improved build speed - incremental builds are now ~10s. Enabled Gradl…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,9 @@ android {
                     'proguard-rules.pro'
             manifestPlaceholders += [crashlyticsEnabled: true]
         }
+        debug {
+            ext.alwaysUpdateBuildId = false
+        }
     }
 
     compileOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 # Daemon heap size 1.5GB
 org.gradle.jvmargs=-Xmx1536M
-org.gradle.daemon=false
+org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 


### PR DESCRIPTION
Improved build speeds - 1 line change incremental builds are now ~10s. Enabled Gradle daemon and set alwaysUpdateBuildId to false for Crashlytics.