### PR TITLE
Fix warnings in FilterTouchHelperCallback

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/recyclerview/FilterTouchHelperCallback.kt
+++ b/app/src/main/java/io/plaidapp/ui/recyclerview/FilterTouchHelperCallback.kt
@@ -172,7 +172,9 @@ class FilterTouchHelperCallback(
                 iconColorFilter = iconColor
             }
             if (circleRadius > 0f) {
-                c.drawCircle(cx, cy, circleRadius, circlePaint)
+                circlePaint?.let { paint ->
+                    c.drawCircle(cx, cy, circleRadius, paint)
+                }
             }
             it.draw(c)
         }


### PR DESCRIPTION
Kotlin now sends let{} warning when it will be used directly.