### PR TITLE
Remove duplicate/nested launch{} call enableLogin()

### DIFF
--- a/designernews/src/main/java/io/plaidapp/designernews/ui/login/LoginViewModel.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/login/LoginViewModel.kt
@@ -107,7 +107,7 @@ class LoginViewModel(
         return username.isNotBlank() && password.isNotBlank()
     }
 
-    private fun enableLogin(enabled: Boolean) = launch {
+    private fun enableLogin(enabled: Boolean) {
         emitUiState(enableLoginButton = enabled)
     }
 


### PR DESCRIPTION
I'm not sure whether the high probability of test fails #493  is result from this dup call, however, it is real confuse to have nested using of `launch{}` there. The `emitUiState()` has a `launch{}` already internal.