### PR TITLE
Fix warnings in ProductHuntPostHolder

### DIFF
--- a/core/src/main/java/io/plaidapp/core/producthunt/ui/ProductHuntPostHolder.kt
+++ b/core/src/main/java/io/plaidapp/core/producthunt/ui/ProductHuntPostHolder.kt
@@ -39,8 +39,8 @@ class ProductHuntPostHolder(
     private var comments: TextView = itemView.findViewById(R.id.story_comments)
 
     init {
-        comments.setOnClickListener { post?.let { commentsClicked(it) } }
-        itemView.setOnClickListener { post?.let { viewClicked(it) } }
+        comments.setOnClickListener { post?.let { post -> commentsClicked(post) } }
+        itemView.setOnClickListener { post?.let { post -> viewClicked(post) } }
     }
 
     fun bind(item: Post) {


### PR DESCRIPTION
Kotlin now sends let{} warning when it will be used directly. Nested-call on `let{}` can bring confused local `it`.