### PR TITLE
Using Kotlin's structured concurrency model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
             'constraintLayout'  : '2.0.0-alpha2',
             'coreKtx'           : '1.0.0',
             'androidxCollection': '1.0.0',
-            'coroutines'        : '0.30.0-eap13',
+            'coroutines'        : '1.0.0-RC1',
             'crashlytics'       : '2.9.4',
             'dagger'            : '2.16',
             'espresso'          : '3.1.0-beta02',

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
             'constraintLayout'  : '2.0.0-alpha2',
             'coreKtx'           : '1.0.0',
             'androidxCollection': '1.0.0',
-            'coroutines'        : '0.26.1-eap13',
+            'coroutines'        : '0.30.0-eap13',
             'crashlytics'       : '2.9.4',
             'dagger'            : '2.16',
             'espresso'          : '3.1.0-beta02',

--- a/core/src/main/java/io/plaidapp/core/AppInjection.kt
+++ b/core/src/main/java/io/plaidapp/core/AppInjection.kt
@@ -20,9 +20,10 @@ package io.plaidapp.core
 
 import android.content.Context
 import android.content.SharedPreferences
-import io.plaidapp.core.data.CoroutinesContextProvider
-import kotlinx.coroutines.CommonPool
-import kotlinx.coroutines.android.UI
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.android.Main
 import okhttp3.logging.HttpLoggingInterceptor
 
 /**
@@ -46,5 +47,9 @@ fun provideSharedPreferences(context: Context, name: String): SharedPreferences 
             .getSharedPreferences(name, Context.MODE_PRIVATE)
 }
 
-@Deprecated("Use Dagger CoroutinesContextProviderModule instead")
-fun provideCoroutinesContextProvider() = CoroutinesContextProvider(UI, CommonPool)
+@Deprecated("Use Dagger CoroutinesDispatcherProviderModule instead")
+fun provideCoroutinesContextProvider() = CoroutinesDispatcherProvider(
+    Dispatchers.Main,
+    Dispatchers.Default,
+    Dispatchers.IO
+)

--- a/core/src/main/java/io/plaidapp/core/AppInjection.kt
+++ b/core/src/main/java/io/plaidapp/core/AppInjection.kt
@@ -22,8 +22,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.android.Main
 import okhttp3.logging.HttpLoggingInterceptor
 
 /**

--- a/core/src/main/java/io/plaidapp/core/dagger/CoroutinesDispatcherProviderModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoroutinesDispatcherProviderModule.kt
@@ -18,14 +18,19 @@ package io.plaidapp.core.dagger
 
 import dagger.Module
 import dagger.Provides
-import io.plaidapp.core.data.CoroutinesContextProvider
-import kotlinx.coroutines.CommonPool
-import kotlinx.coroutines.android.UI
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.android.Main
 
 /**
- * Provide [CoroutinesContextProvider] to this app's components.
+ * Provide [CoroutinesDispatcherProvider] to this app's components.
  */
-@Module class CoroutinesContextProviderModule {
+@Module class CoroutinesDispatcherProviderModule {
 
-    @Provides fun provideCoroutinesContextProvider() = CoroutinesContextProvider(UI, CommonPool)
+    @Provides fun provideCoroutinesDispatcherProvider() = CoroutinesDispatcherProvider(
+        Dispatchers.Main,
+        Dispatchers.Default,
+        Dispatchers.IO
+    )
 }

--- a/core/src/main/java/io/plaidapp/core/dagger/CoroutinesDispatcherProviderModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoroutinesDispatcherProviderModule.kt
@@ -20,15 +20,15 @@ import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.android.Main
 
 /**
  * Provide [CoroutinesDispatcherProvider] to this app's components.
  */
-@Module class CoroutinesDispatcherProviderModule {
+@Module
+class CoroutinesDispatcherProviderModule {
 
-    @Provides fun provideCoroutinesDispatcherProvider() = CoroutinesDispatcherProvider(
+    @Provides
+    fun provideCoroutinesDispatcherProvider() = CoroutinesDispatcherProvider(
         Dispatchers.Main,
         Dispatchers.Default,
         Dispatchers.IO

--- a/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
@@ -20,8 +20,8 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.BuildConfig
-import io.plaidapp.core.dagger.CoroutinesContextProviderModule
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.dagger.CoroutinesDispatcherProviderModule
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.search.DribbbleSearchConverter
 import io.plaidapp.core.dribbble.data.search.DribbbleSearchService
@@ -34,14 +34,14 @@ import retrofit2.Retrofit
 /**
  * Dagger module providing classes required to dribbble with data.
  */
-@Module(includes = [CoroutinesContextProviderModule::class])
+@Module(includes = [CoroutinesDispatcherProviderModule::class])
 class DribbbleDataModule {
 
     @Provides
     fun provideShotsRepository(
         remoteDataSource: SearchRemoteDataSource,
-        contextProvider: CoroutinesContextProvider
-    ) = ShotsRepository.getInstance(remoteDataSource, contextProvider)
+        dispatcherProvider: CoroutinesDispatcherProvider
+    ) = ShotsRepository.getInstance(remoteDataSource, dispatcherProvider)
 
     @Provides
     fun provideDribbbleSearchService(): DribbbleSearchService =

--- a/core/src/main/java/io/plaidapp/core/data/CoroutinesDispatcherProvider.kt
+++ b/core/src/main/java/io/plaidapp/core/data/CoroutinesDispatcherProvider.kt
@@ -16,9 +16,13 @@
 
 package io.plaidapp.core.data
 
-import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
 
 /**
  * Provide coroutines context.
  */
-data class CoroutinesContextProvider(val main: CoroutineContext, val io: CoroutineContext)
+data class CoroutinesDispatcherProvider(
+    val main: CoroutineDispatcher,
+    val computation: CoroutineDispatcher,
+    val io: CoroutineDispatcher
+)

--- a/core/src/main/java/io/plaidapp/core/designernews/domain/LoadStoriesUseCase.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/domain/LoadStoriesUseCase.kt
@@ -22,6 +22,7 @@ import io.plaidapp.core.data.Result
 import io.plaidapp.core.data.prefs.SourceManager
 import io.plaidapp.core.designernews.data.stories.StoriesRepository
 import io.plaidapp.core.designernews.data.stories.model.toStory
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -44,7 +45,7 @@ class LoadStoriesUseCase(
         page: Int,
         callback: LoadSourceCallback,
         jobId: String
-    ) = launch(dispatcherProvider.io) {
+    ) = GlobalScope.launch(dispatcherProvider.computation) {
         val result = storiesRepository.loadStories(page)
         parentJobs.remove(jobId)
         if (result is Result.Success) {

--- a/core/src/main/java/io/plaidapp/core/designernews/domain/LoadStoriesUseCase.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/domain/LoadStoriesUseCase.kt
@@ -16,7 +16,7 @@
 
 package io.plaidapp.core.designernews.domain
 
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.LoadSourceCallback
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.data.prefs.SourceManager
@@ -31,7 +31,7 @@ import kotlinx.coroutines.withContext
  */
 class LoadStoriesUseCase(
     private val storiesRepository: StoriesRepository,
-    private val contextProvider: CoroutinesContextProvider
+    private val dispatcherProvider: CoroutinesDispatcherProvider
 ) {
     private val parentJobs = mutableMapOf<String, Job>()
 
@@ -44,16 +44,16 @@ class LoadStoriesUseCase(
         page: Int,
         callback: LoadSourceCallback,
         jobId: String
-    ) = launch(contextProvider.io) {
+    ) = launch(dispatcherProvider.io) {
         val result = storiesRepository.loadStories(page)
         parentJobs.remove(jobId)
         if (result is Result.Success) {
             val stories = result.data.map { it.toStory() }
-            withContext(contextProvider.main) {
+            withContext(dispatcherProvider.main) {
                 callback.sourceLoaded(stories, page, SourceManager.SOURCE_DESIGNER_NEWS_POPULAR)
             }
         } else {
-            withContext(contextProvider.main) {
+            withContext(dispatcherProvider.main) {
                 callback.loadFailed(SourceManager.SOURCE_DESIGNER_NEWS_POPULAR)
             }
         }

--- a/core/src/main/java/io/plaidapp/core/designernews/domain/SearchStoriesUseCase.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/domain/SearchStoriesUseCase.kt
@@ -16,7 +16,7 @@
 
 package io.plaidapp.core.designernews.domain
 
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.LoadSourceCallback
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.stories.StoriesRepository
@@ -30,7 +30,7 @@ import kotlinx.coroutines.withContext
  */
 class SearchStoriesUseCase(
     private val storiesRepository: StoriesRepository,
-    private val contextProvider: CoroutinesContextProvider
+    private val dispatcherProvider: CoroutinesDispatcherProvider
 ) {
     private val parentJobs = mutableMapOf<String, Job>()
 
@@ -44,16 +44,16 @@ class SearchStoriesUseCase(
         page: Int,
         callback: LoadSourceCallback,
         jobId: String
-    ) = launch(contextProvider.io) {
+    ) = launch(dispatcherProvider.io) {
         val result = storiesRepository.search(query, page)
         parentJobs.remove(jobId)
         if (result is Result.Success) {
             val stories = result.data.map { it.toStory() }
-            withContext(contextProvider.main) {
+            withContext(dispatcherProvider.main) {
                 callback.sourceLoaded(stories, page, query)
             }
         } else {
-            withContext(contextProvider.main) { callback.loadFailed(query) }
+            withContext(dispatcherProvider.main) { callback.loadFailed(query) }
         }
     }
 

--- a/core/src/main/java/io/plaidapp/core/designernews/domain/SearchStoriesUseCase.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/domain/SearchStoriesUseCase.kt
@@ -21,6 +21,7 @@ import io.plaidapp.core.data.LoadSourceCallback
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.stories.StoriesRepository
 import io.plaidapp.core.designernews.data.stories.model.toStory
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -44,7 +45,7 @@ class SearchStoriesUseCase(
         page: Int,
         callback: LoadSourceCallback,
         jobId: String
-    ) = launch(dispatcherProvider.io) {
+    ) = GlobalScope.launch(dispatcherProvider.computation) {
         val result = storiesRepository.search(query, page)
         parentJobs.remove(jobId)
         if (result is Result.Success) {

--- a/core/src/main/java/io/plaidapp/core/dribbble/data/ShotsRepository.kt
+++ b/core/src/main/java/io/plaidapp/core/dribbble/data/ShotsRepository.kt
@@ -20,6 +20,7 @@ import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.dribbble.data.search.SearchRemoteDataSource
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -63,7 +64,7 @@ class ShotsRepository constructor(
         page: Int,
         id: String,
         onResult: (Result<List<Shot>>) -> Unit
-    ) = launch(dispatcherProvider.io) {
+    ) = GlobalScope.launch(dispatcherProvider.io) {
         val result = remoteDataSource.search(query, page)
         inflight.remove(id)
         if (result is Result.Success) {

--- a/core/src/test/java/io/plaidapp/core/designernews/domain/LoadStoriesUseCaseTest.kt
+++ b/core/src/test/java/io/plaidapp/core/designernews/domain/LoadStoriesUseCaseTest.kt
@@ -27,7 +27,7 @@ import io.plaidapp.core.designernews.data.stories.model.Story
 import io.plaidapp.core.designernews.data.stories.model.StoryResponse
 import io.plaidapp.core.designernews.storyLinks
 import io.plaidapp.core.designernews.userId
-import io.plaidapp.test.shared.provideFakeCoroutinesContextProvider
+import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -74,7 +74,7 @@ class LoadStoriesUseCaseTest {
     private val storiesRepository: StoriesRepository = mock()
     private val loadStoriesUseCase = LoadStoriesUseCase(
         storiesRepository,
-        provideFakeCoroutinesContextProvider()
+        provideFakeCoroutinesDispatcherProvider()
     )
 
     @Test

--- a/core/src/test/java/io/plaidapp/core/designernews/domain/SearchStoriesUseCaseTest.kt
+++ b/core/src/test/java/io/plaidapp/core/designernews/domain/SearchStoriesUseCaseTest.kt
@@ -26,7 +26,7 @@ import io.plaidapp.core.designernews.data.stories.model.Story
 import io.plaidapp.core.designernews.data.stories.model.StoryResponse
 import io.plaidapp.core.designernews.storyLinks
 import io.plaidapp.core.designernews.userId
-import io.plaidapp.test.shared.provideFakeCoroutinesContextProvider
+import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -74,7 +74,7 @@ class SearchStoriesUseCaseTest {
     private val storiesRepository: StoriesRepository = mock()
     private val searchStoriesUseCase = SearchStoriesUseCase(
         storiesRepository,
-        provideFakeCoroutinesContextProvider()
+        provideFakeCoroutinesDispatcherProvider()
     )
 
     @Test

--- a/core/src/test/java/io/plaidapp/core/dribbble/data/ShotsRepositoryTest.kt
+++ b/core/src/test/java/io/plaidapp/core/dribbble/data/ShotsRepositoryTest.kt
@@ -22,7 +22,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.dribbble.data.search.SearchRemoteDataSource
-import io.plaidapp.test.shared.provideFakeCoroutinesContextProvider
+import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -38,7 +38,7 @@ class ShotsRepositoryTest {
     private val dataSource: SearchRemoteDataSource = mock()
     private val repository = ShotsRepository(
         dataSource,
-        provideFakeCoroutinesContextProvider()
+        provideFakeCoroutinesDispatcherProvider()
     )
     private val query = "Plaid shirts"
     private val page = 0

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -67,3 +67,4 @@ dependencies {
     // Workaround for dependency conflict during assembleAndroidTest
     androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
 }
+

--- a/designernews/src/main/java/io/plaidapp/designernews/ui/DesignerNewsViewModelFactory.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/DesignerNewsViewModelFactory.kt
@@ -18,7 +18,7 @@ package io.plaidapp.designernews.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.designernews.ui.login.LoginViewModel
 
@@ -27,13 +27,13 @@ import io.plaidapp.designernews.ui.login.LoginViewModel
  */
 class DesignerNewsViewModelFactory(
     private val loginRepository: LoginRepository,
-    private val contextProvider: CoroutinesContextProvider
+    private val dispatcherProvider: CoroutinesDispatcherProvider
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(LoginViewModel::class.java)) {
-            return LoginViewModel(loginRepository, contextProvider) as T
+            return LoginViewModel(loginRepository, dispatcherProvider) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/ui/login/LoginViewModel.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/login/LoginViewModel.kt
@@ -64,8 +64,8 @@ class LoginViewModel(
         loginJob = launchLogin(username, password)
     }
 
-    private fun launchLogin(username: String, password: String) =
-        scope.launch(dispatcherProvider.computation) {
+    private fun launchLogin(username: String, password: String): Job {
+        return scope.launch(dispatcherProvider.computation) {
             if (!isLoginValid(username, password)) {
                 return@launch
             }
@@ -91,6 +91,7 @@ class LoginViewModel(
                 }
             }
         }
+    }
 
     private fun showLoading() {
         emitUiState(showProgress = true)

--- a/designernews/src/main/java/io/plaidapp/designernews/ui/login/LoginViewModel.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/login/LoginViewModel.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import io.plaidapp.R
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.util.event.Event
@@ -34,7 +34,7 @@ private const val signupUrl = "https://www.designernews.co/users/new"
 
 class LoginViewModel(
     private val loginRepository: LoginRepository,
-    private val contextProvider: CoroutinesContextProvider
+    private val dispatcherProvider: CoroutinesDispatcherProvider
 ) : ViewModel() {
 
     private var currentJob: Job? = null
@@ -60,7 +60,7 @@ class LoginViewModel(
         currentJob = launchLogin(username, password)
     }
 
-    private fun launchLogin(username: String, password: String) = launch(contextProvider.io) {
+    private fun launchLogin(username: String, password: String) = launch(dispatcherProvider.io) {
         if (!isLoginValid(username, password)) {
             return@launch
         }
@@ -116,7 +116,7 @@ class LoginViewModel(
         showError: Event<Int>? = null,
         showSuccess: Event<LoginResultUiModel>? = null,
         enableLoginButton: Boolean = false
-    ) = launch(contextProvider.main, parent = currentJob) {
+    ) = launch(dispatcherProvider.main, parent = currentJob) {
         val uiModel = LoginUiModel(showProgress, showError, showSuccess, enableLoginButton)
         _uiState.value = uiModel
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryViewModelFactory.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/ui/story/StoryViewModelFactory.kt
@@ -18,7 +18,7 @@ package io.plaidapp.designernews.ui.story
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.designernews.domain.GetCommentsWithRepliesAndUsersUseCase
 import io.plaidapp.designernews.domain.GetStoryUseCase
 import io.plaidapp.designernews.domain.PostReplyUseCase
@@ -37,7 +37,7 @@ class StoryViewModelFactory(
     private val getCommentsWithRepliesAndUsersUseCase: GetCommentsWithRepliesAndUsersUseCase,
     private val upvoteStoryUseCase: UpvoteStoryUseCase,
     private val upvoteCommentUseCase: UpvoteCommentUseCase,
-    private val contextProvider: CoroutinesContextProvider
+    private val dispatcherProvider: CoroutinesDispatcherProvider
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
@@ -53,7 +53,7 @@ class StoryViewModelFactory(
             getCommentsWithRepliesAndUsersUseCase,
             upvoteStoryUseCase,
             upvoteCommentUseCase,
-            contextProvider
+            dispatcherProvider
         ) as T
     }
 }

--- a/designernews/src/test/java/io/plaidapp/designernews/ui/login/LoginViewModelTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/ui/login/LoginViewModelTest.kt
@@ -27,7 +27,7 @@ import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser
 import io.plaidapp.core.util.event.Event
 import io.plaidapp.test.shared.LiveDataTestUtil
-import io.plaidapp.test.shared.provideFakeCoroutinesContextProvider
+import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -58,7 +58,7 @@ class LoginViewModelTest {
     @Test
     fun login_whenUserLoggedInSuccessfully() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
         // Given that the repository returns a user
         val user = LoggedInUser(
             id = 3,
@@ -88,7 +88,7 @@ class LoginViewModelTest {
     @Test
     fun login_whenUserLogInFailed() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
         // Given that the repository returns with error
         whenever(loginRepo.login(username, password))
             .thenReturn(Result.Error(IOException("Login error")))
@@ -110,7 +110,7 @@ class LoginViewModelTest {
     @Test
     fun init_disablesLogin() = runBlocking {
         // When the view model is created
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // Then the login is disabled
         val uiState = LiveDataTestUtil.getValue(viewModel.uiState)
@@ -120,7 +120,7 @@ class LoginViewModelTest {
     @Test
     fun loginDataChanged_withValidLogin() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // When login data changed with valid login data
         viewModel.loginDataChanged(username, password)
@@ -144,7 +144,7 @@ class LoginViewModelTest {
     @Test
     fun loginDataChanged_withEmptyUsername() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // When login data changed with invalid login data
         viewModel.loginDataChanged("", password)
@@ -163,7 +163,7 @@ class LoginViewModelTest {
     @Test
     fun loginDataChanged_withEmptyPassword() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // When login data changed with invalid login data
         viewModel.loginDataChanged(username, "")
@@ -182,7 +182,7 @@ class LoginViewModelTest {
     @Test
     fun login_withEmptyUsername() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // When logging in with invalid login data
         viewModel.login("", password)
@@ -197,7 +197,7 @@ class LoginViewModelTest {
     @Test
     fun login_withEmptyPassword() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // When logging in with invalid login data
         viewModel.loginDataChanged(username, "")
@@ -212,7 +212,7 @@ class LoginViewModelTest {
     @Test
     fun signup() = runBlocking {
         // Given a view model
-        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesContextProvider())
+        val viewModel = LoginViewModel(loginRepo, provideFakeCoroutinesDispatcherProvider())
 
         // When signing up
         viewModel.signup()

--- a/designernews/src/test/java/io/plaidapp/designernews/ui/story/StoryViewModelTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/ui/story/StoryViewModelTest.kt
@@ -32,7 +32,7 @@ import io.plaidapp.designernews.domain.UpvoteStoryUseCase
 import io.plaidapp.designernews.flattendCommentsWithReplies
 import io.plaidapp.designernews.reply1
 import io.plaidapp.test.shared.LiveDataTestUtil
-import io.plaidapp.test.shared.provideFakeCoroutinesContextProvider
+import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -102,7 +102,7 @@ class StoryViewModelTest {
             getCommentsWithRepliesAndUsers,
             upvoteStory,
             upvoteComment,
-            provideFakeCoroutinesContextProvider()
+            provideFakeCoroutinesDispatcherProvider()
         )
         // Then it throws
     }
@@ -267,7 +267,7 @@ class StoryViewModelTest {
             getCommentsWithRepliesAndUsers,
             upvoteStory,
             upvoteComment,
-            provideFakeCoroutinesContextProvider()
+            provideFakeCoroutinesDispatcherProvider()
         )
     }
 }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
 import io.plaidapp.core.util.FileAuthority
@@ -58,13 +58,13 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     fun shotViewModelFactory(
         shotsRepository: ShotsRepository,
         shareShotInfoUseCase: GetShareShotInfoUseCase,
-        coroutinesContextProvider: CoroutinesContextProvider
+        coroutinesDispatcherProvider: CoroutinesDispatcherProvider
     ): ShotViewModelFactory {
         return ShotViewModelFactory(
             shotId,
             shotsRepository,
             shareShotInfoUseCase,
-            coroutinesContextProvider
+            coroutinesDispatcherProvider
         )
     }
 

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
@@ -19,7 +19,7 @@ package io.plaidapp.dribbble.ui.shot
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.api.model.Shot
@@ -37,7 +37,7 @@ class ShotViewModel @Inject constructor(
     shotId: Long,
     shotsRepository: ShotsRepository,
     private val getShareShotInfoUseCase: GetShareShotInfoUseCase,
-    private val contextProvider: CoroutinesContextProvider
+    private val dispatcherProvider: CoroutinesDispatcherProvider
 ) : ViewModel() {
 
     val shot: Shot
@@ -75,7 +75,7 @@ class ShotViewModel @Inject constructor(
         shareShotJob?.cancel()
     }
 
-    private fun launchShare() = launch(contextProvider.io) {
+    private fun launchShare() = launch(dispatcherProvider.io) {
         val shareInfo = getShareShotInfoUseCase(shot)
         _shareShot.postValue(Event(shareInfo))
     }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModelFactory.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModelFactory.kt
@@ -18,7 +18,7 @@ package io.plaidapp.dribbble.ui.shot
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.dribbble.domain.GetShareShotInfoUseCase
 import javax.inject.Inject
@@ -30,7 +30,7 @@ class ShotViewModelFactory @Inject constructor(
     private val shotId: Long,
     private val shotRepository: ShotsRepository,
     private val getShareShotInfoUseCase: GetShareShotInfoUseCase,
-    private val contextProvider: CoroutinesContextProvider
+    private val dispatcherProvider: CoroutinesDispatcherProvider
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
@@ -42,7 +42,7 @@ class ShotViewModelFactory @Inject constructor(
             shotId,
             shotRepository,
             getShareShotInfoUseCase,
-            contextProvider
+            dispatcherProvider
         ) as T
     }
 }

--- a/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
@@ -28,7 +28,7 @@ import io.plaidapp.dribbble.domain.GetShareShotInfoUseCase
 import io.plaidapp.dribbble.domain.ShareShotInfo
 import io.plaidapp.dribbble.testShot
 import io.plaidapp.test.shared.LiveDataTestUtil
-import io.plaidapp.test.shared.provideFakeCoroutinesContextProvider
+import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -68,7 +68,7 @@ class ShotViewModelTest {
             shotId,
             repo,
             getShareShotInfoUseCase,
-            provideFakeCoroutinesContextProvider()
+            provideFakeCoroutinesDispatcherProvider()
         )
         // Then it throws
     }
@@ -117,7 +117,7 @@ class ShotViewModelTest {
             shotId,
             repo,
             getShareShotInfoUseCase,
-            provideFakeCoroutinesContextProvider()
+            provideFakeCoroutinesDispatcherProvider()
         )
     }
 }

--- a/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
@@ -16,8 +16,8 @@
 
 package io.plaidapp.test.shared
 
-import io.plaidapp.core.data.CoroutinesContextProvider
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import kotlinx.coroutines.Dispatchers.Unconfined
 
-fun provideFakeCoroutinesContextProvider(): CoroutinesContextProvider =
-        CoroutinesContextProvider(Unconfined, Unconfined)
+fun provideFakeCoroutinesDispatcherProvider(): CoroutinesDispatcherProvider =
+    CoroutinesDispatcherProvider(Unconfined, Unconfined, Unconfined)


### PR DESCRIPTION
ViewModels have a scope and the parent job gets cancelled in `onCleared`
Repositories and UseCases, that are still called from Java and use the mix of coroutines and callbacks, since they also offer a way of cancelling the tasks, are using the `GlobalScope` to launch coroutines. 