### PR TITLE
Update imports for Testing

### DIFF
--- a/app/src/androidTest/java/io/plaidapp/ui/HomeActivityTest.kt
+++ b/app/src/androidTest/java/io/plaidapp/ui/HomeActivityTest.kt
@@ -16,7 +16,6 @@
 
 package io.plaidapp.ui
 
-import androidx.test.InstrumentationRegistry
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -26,6 +25,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
 import android.view.Gravity
+import androidx.test.platform.app.InstrumentationRegistry
 import io.plaidapp.R
 import org.junit.Rule
 import org.junit.Test

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -116,12 +116,6 @@ dependencies {
     androidTestImplementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
 }
 
-kotlin {
-    experimental {
-        coroutines 'enable'
-    }
-}
-
 androidExtensions {
     experimental = true
 }

--- a/core/src/androidTest/java/io/plaidapp/core/designernews/data/database/LoggedInUserDaoTest.kt
+++ b/core/src/androidTest/java/io/plaidapp/core/designernews/data/database/LoggedInUserDaoTest.kt
@@ -18,7 +18,7 @@ package io.plaidapp.core.designernews.data.database
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser
 import io.plaidapp.test.shared.LiveDataTestUtil
 import org.junit.After

--- a/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSourceTest.kt
+++ b/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSourceTest.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.core.designernews.data.login
 
 import android.content.Context
-import androidx.test.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull

--- a/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/LoginLocalDataSourceTest.kt
+++ b/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/LoginLocalDataSourceTest.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.core.designernews.data.login
 
 import android.content.Context
-import androidx.test.InstrumentationRegistry.getInstrumentation
+import androidx.test.platform.app.InstrumentationRegistry
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -30,7 +30,7 @@ import org.junit.Test
  */
 class LoginLocalDataSourceTest {
 
-    private var sharedPreferences = getInstrumentation().context
+    private var sharedPreferences = InstrumentationRegistry.getInstrumentation().context
         .getSharedPreferences("test", Context.MODE_PRIVATE)
 
     private var dataSource = LoginLocalDataSource(sharedPreferences)

--- a/core/src/androidTest/java/io/plaidapp/core/dribbble/data/prefs/DribbbleV1SourceRemoverTest.kt
+++ b/core/src/androidTest/java/io/plaidapp/core/dribbble/data/prefs/DribbbleV1SourceRemoverTest.kt
@@ -17,8 +17,8 @@
 package io.plaidapp.core.dribbble.data.prefs
 
 import android.content.Context
-import androidx.test.InstrumentationRegistry
 import androidx.core.content.edit
+import androidx.test.platform.app.InstrumentationRegistry
 import io.plaidapp.core.data.prefs.checkAndRemove
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/core/src/androidTest/java/io/plaidapp/core/util/TextViewExtensionTest.kt
+++ b/core/src/androidTest/java/io/plaidapp/core/util/TextViewExtensionTest.kt
@@ -16,15 +16,15 @@
 
 package io.plaidapp.core.util
 
-import androidx.test.InstrumentationRegistry
 import android.widget.TextView
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicBoolean
 
 class TextViewExtensionTest {
 
-    private val context = InstrumentationRegistry.getContext()
+    private val context = InstrumentationRegistry.getInstrumentation().context
     private val view = TextView(context)
 
     @Test

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -65,9 +65,3 @@ dependencies {
     // Workaround for dependency conflict during assembleAndroidTest
     androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
 }
-
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
-}

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -64,9 +64,3 @@ dependencies {
     // Workaround for dependency conflict during assembleAndroidTest
     androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
 }
-
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
-}

--- a/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.test.shared
 
 import io.plaidapp.core.data.CoroutinesContextProvider
-import kotlinx.coroutines.Unconfined
+import kotlinx.coroutines.Dispatchers.Unconfined
 
 fun provideFakeCoroutinesContextProvider(): CoroutinesContextProvider =
         CoroutinesContextProvider(Unconfined, Unconfined)


### PR DESCRIPTION
- Replace deprecated [`androidx.test.InstrumentationRegistry`](https://developer.android.com/reference/androidx/test/InstrumentationRegistry) with suggested replacement `test.platform.app.InstrumentationRegistry`
- Update deprecated import `Unconfined` to `Dispatchers.Unconfined`
- Also remove explicit declaration for coroutines as it's already included in Kotlin 1.3