### PR TITLE
Group and dedupe dependencies related to runtime classpath workaround

### DIFF
--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -50,8 +50,6 @@ repositories {
 
 dependencies {
     implementation project(':app')
-    implementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
-    implementation "androidx.collection:collection:${versions.androidxCollection}"
 
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
 
@@ -63,9 +61,10 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
 
     // Work around issue with runtime classpath version conflict
+    implementation "androidx.arch.core:core-runtime:${versions.androidxCoreRuntime}"
+    implementation "androidx.collection:collection:${versions.androidxCollection}"
     implementation "androidx.legacy:legacy-support-core-utils:${versions.legacyCoreUtils}"
     implementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
-    implementation "androidx.arch.core:core-runtime:${versions.androidxCoreRuntime}"
 
     // Workaround for dependency conflict during assembleAndroidTest
     androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -48,8 +48,6 @@ repositories {
 
 dependencies {
     implementation project(':app')
-    implementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
-    implementation "androidx.collection:collection:${versions.androidxCollection}"
 
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
 
@@ -60,9 +58,10 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
 
     // Work around issue with runtime classpath version conflict
+    implementation "androidx.arch.core:core-runtime:${versions.androidxCoreRuntime}"
+    implementation "androidx.collection:collection:${versions.androidxCollection}"
     implementation "androidx.legacy:legacy-support-core-utils:${versions.legacyCoreUtils}"
     implementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
-    implementation "androidx.arch.core:core-runtime:${versions.androidxCoreRuntime}"
 
     // Workaround for dependency conflict during assembleAndroidTest
     androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")


### PR DESCRIPTION
https://github.com/nickbutcher/plaid/commit/358e6ba560b974f4afddae36070f3a99cc5f9228 and https://github.com/nickbutcher/plaid/commit/b8f243c4f32e3380aca003742802fa53abcd4356 resulted in a duplicate reference to the `lifecycle-runtime` dependency.