### PR TITLE
Only cancel the children of the ShotsRepository.

### DIFF
--- a/core/src/main/java/io/plaidapp/core/dribbble/data/ShotsRepository.kt
+++ b/core/src/main/java/io/plaidapp/core/dribbble/data/ShotsRepository.kt
@@ -22,6 +22,7 @@ import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.dribbble.data.search.SearchRemoteDataSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -33,7 +34,7 @@ class ShotsRepository constructor(
     private val dispatcherProvider: CoroutinesDispatcherProvider
 ) {
 
-    private var parentJob = Job()
+    private val parentJob = Job()
     private val scope = CoroutineScope(dispatcherProvider.main + parentJob)
 
     private val inflight = mutableMapOf<String, Job>()
@@ -58,7 +59,7 @@ class ShotsRepository constructor(
     }
 
     fun cancelAllSearches() {
-        parentJob.cancel()
+        parentJob.cancelChildren()
         inflight.clear()
     }
 


### PR DESCRIPTION
ShotsRepository is a singleton that lives in the scope of the app. Once cancelAllSearches was called, no other calls could have been triggered, because the parent job was canceled (once a job was cancelled it cannot be active again. See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-job/index.html ).
So for now, we're just cancelling the children.

Future, ideal fix - remove the job launching from the Repository