### PR TITLE
Use implementation instead of api

### DIFF
--- a/about/build.gradle
+++ b/about/build.gradle
@@ -19,6 +19,9 @@ apply plugin: 'com.android.dynamic-feature'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
+apply from: '../core_dependencies.gradle'
+apply from: '../test_dependencies.gradle'
+
 android {
     compileSdkVersion versions.compileSdk
 
@@ -45,19 +48,7 @@ repositories {
 
 dependencies {
     implementation project(':app')
+    implementation project(':core')
+
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
-
-    testImplementation project(':test_shared')
-    testImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}"
-    testImplementation "junit:junit:${versions.junit}"
-
-    androidTestImplementation project(':test_shared')
-    androidTestImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
-    androidTestImplementation "androidx.test:runner:${versions.test_runner}"
-    androidTestImplementation "androidx.test:rules:${versions.test_rules}"
-    androidTestImplementation "androidx.test.espresso:espresso-core:${versions.espresso}"
-    androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}"
-    androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"
-    androidTestImplementation "org.mockito:mockito-core:${versions.mockito}"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,9 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
+apply from: '../core_dependencies.gradle'
+apply from: '../test_dependencies.gradle'
+
 android {
     compileSdkVersion versions.compileSdk
 
@@ -74,14 +77,11 @@ repositories {
 }
 
 dependencies {
-    api project(':core')
+    implementation project(':core')
 
     implementation "com.crashlytics.sdk.android:crashlytics:${versions.crashlytics}"
     implementation "com.google.firebase:firebase-core:${versions.firebase}"
 
-    androidTestImplementation "androidx.test:rules:${versions.test_rules}"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:${versions.espresso}"
-    androidTestImplementation "androidx.test.uiautomator:uiautomator:${versions.ui_automator}"
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,6 +20,9 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
+apply from: '../core_dependencies.gradle'
+apply from: '../test_dependencies.gradle'
+
 android {
     compileSdkVersion versions.compileSdk
 
@@ -66,59 +69,9 @@ repositories {
 }
 
 dependencies {
-    api project(':bypass')
-
-    api "androidx.room:room-runtime:${versions.room}"
-    api "androidx.core:core-ktx:${versions.coreKtx}"
-    api "androidx.constraintlayout:constraintlayout:${versions.constraintLayout}"
-    api "androidx.browser:browser:${versions.androidx}"
-    api "androidx.palette:palette:${versions.androidx}"
-    api "androidx.recyclerview:recyclerview:${versions.androidx}"
-    api "androidx.dynamicanimation:dynamicanimation:${versions.androidx}"
-    api "com.android.support:customtabs:${versions.supportLibrary}"
-    api "com.android.support:design:${versions.supportLibrary}"
-    api "com.android.support:palette-v7:${versions.supportLibrary}"
-    api "com.android.support:support-v4:${versions.supportLibrary}" // Required for version pinning.
-    api "com.android.support:support-dynamic-animation:${versions.supportLibrary}"
-    api "com.github.bumptech.glide:glide:${versions.glide}"
-    api "com.github.bumptech.glide:okhttp3-integration:${versions.glide}"
-    api "com.github.bumptech.glide:recyclerview-integration:${versions.glide}"
-    api "com.google.android.material:material:${versions.material}"
-    api "com.google.code.gson:gson:${versions.gson}"
-    api "com.google.dagger:dagger:${versions.dagger}"
-    api "com.squareup.retrofit2:retrofit:${versions.retrofit}"
-    api "com.squareup.retrofit2:converter-gson:${versions.retrofit}"
-    api "com.squareup.okhttp3:okhttp:${versions.okhttp}"
-    api "com.squareup.okhttp3:logging-interceptor:${versions.okhttp}"
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
-    api "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
-    api "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:${versions.retrofitCoroutines}"
-    api "org.jsoup:jsoup:${versions.jsoup}"
-    api "androidx.lifecycle:lifecycle-viewmodel:${versions.lifecycle}"
-    api "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}"
     kapt "androidx.room:room-compiler:${versions.room}"
     kapt "com.github.bumptech.glide:compiler:${versions.glide}"
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
-
-    testImplementation project(':test_shared')
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}"
-    testImplementation "com.squareup.retrofit2:retrofit-mock:${versions.retrofit}"
-    testImplementation "junit:junit:${versions.junit}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
-
-    androidTestImplementation project(':test_shared')
-    androidTestImplementation "androidx.test:runner:${versions.test_runner}"
-    androidTestImplementation "androidx.test:rules:${versions.test_rules}"
-    androidTestImplementation "androidx.test.espresso:espresso-core:${versions.espresso}"
-    androidTestImplementation "org.mockito:mockito-core:${versions.mockito}"
-    androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"
-    androidTestImplementation "com.squareup.retrofit2:retrofit-mock:${versions.retrofit}"
-
-    // Work around issue with runtime classpath version conflict
-    androidTestImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
-    androidTestImplementation "androidx.legacy:legacy-support-core-utils:${versions.legacyCoreUtils}"
-    androidTestImplementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
 }
 
 androidExtensions {

--- a/core_dependencies.gradle
+++ b/core_dependencies.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+dependencies {
+    implementation project(':bypass')
+
+    implementation "androidx.room:room-runtime:${versions.room}"
+    implementation "androidx.core:core-ktx:${versions.coreKtx}"
+    implementation "androidx.constraintlayout:constraintlayout:${versions.constraintLayout}"
+    implementation "androidx.browser:browser:${versions.androidx}"
+    implementation "androidx.palette:palette:${versions.androidx}"
+    implementation "androidx.recyclerview:recyclerview:${versions.androidx}"
+    implementation "androidx.dynamicanimation:dynamicanimation:${versions.androidx}"
+    implementation "com.android.support:customtabs:${versions.supportLibrary}"
+    implementation "com.android.support:design:${versions.supportLibrary}"
+    implementation "com.android.support:palette-v7:${versions.supportLibrary}"
+    implementation "com.android.support:support-v4:${versions.supportLibrary}" // Required for version pinning.
+    implementation "com.android.support:support-dynamic-animation:${versions.supportLibrary}"
+    implementation "com.github.bumptech.glide:glide:${versions.glide}"
+    implementation "com.github.bumptech.glide:okhttp3-integration:${versions.glide}"
+    implementation "com.github.bumptech.glide:recyclerview-integration:${versions.glide}"
+    implementation "com.google.android.material:material:${versions.material}"
+    implementation "com.google.code.gson:gson:${versions.gson}"
+    implementation "com.google.dagger:dagger:${versions.dagger}"
+    implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
+    implementation "com.squareup.retrofit2:converter-gson:${versions.retrofit}"
+    implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
+    implementation "com.squareup.okhttp3:logging-interceptor:${versions.okhttp}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}"
+    implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:${versions.retrofitCoroutines}"
+    implementation "org.jsoup:jsoup:${versions.jsoup}"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:${versions.lifecycle}"
+    implementation "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}"
+}

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -20,6 +20,9 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
+apply from: '../core_dependencies.gradle'
+apply from: '../test_dependencies.gradle'
+
 android {
     compileSdkVersion versions.compileSdk
 
@@ -50,23 +53,8 @@ repositories {
 
 dependencies {
     implementation project(':app')
+    implementation project(':core')
 
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
-
-    testImplementation project(':test_shared')
-
-    testImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}"
-    testImplementation "junit:junit:${versions.junit}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
-
-    // Work around issue with runtime classpath version conflict
-    implementation "androidx.arch.core:core-runtime:${versions.androidxCoreRuntime}"
-    implementation "androidx.collection:collection:${versions.androidxCollection}"
-    implementation "androidx.legacy:legacy-support-core-utils:${versions.legacyCoreUtils}"
-    implementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
-
-    // Workaround for dependency conflict during assembleAndroidTest
-    androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
 }
 

--- a/dribbble/build.gradle
+++ b/dribbble/build.gradle
@@ -19,6 +19,9 @@ apply plugin: 'com.android.dynamic-feature'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
+apply from: '../core_dependencies.gradle'
+apply from: '../test_dependencies.gradle'
+
 android {
     compileSdkVersion versions.compileSdk
 
@@ -48,21 +51,7 @@ repositories {
 
 dependencies {
     implementation project(':app')
+    implementation project(':core')
 
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
-
-    testImplementation project(':test_shared')
-    testImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}"
-    testImplementation "junit:junit:${versions.junit}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
-
-    // Work around issue with runtime classpath version conflict
-    implementation "androidx.arch.core:core-runtime:${versions.androidxCoreRuntime}"
-    implementation "androidx.collection:collection:${versions.androidxCollection}"
-    implementation "androidx.legacy:legacy-support-core-utils:${versions.legacyCoreUtils}"
-    implementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
-
-    // Workaround for dependency conflict during assembleAndroidTest
-    androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
 }

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -19,6 +19,9 @@ apply plugin: 'com.android.dynamic-feature'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
+apply from: '../core_dependencies.gradle'
+apply from: '../test_dependencies.gradle'
+
 android {
     compileSdkVersion versions.compileSdk
 
@@ -41,6 +44,7 @@ repositories {
 
 dependencies {
     implementation project(':app')
+    implementation project(':core')
 
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
 

--- a/test_dependencies.gradle
+++ b/test_dependencies.gradle
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+dependencies {
+    testImplementation project(':test_shared')
+    testImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}"
+    testImplementation "com.squareup.retrofit2:retrofit-mock:${versions.retrofit}"
+    testImplementation "junit:junit:${versions.junit}"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+
+    // Work around issue with runtime classpath version conflict
+    implementation "androidx.arch.core:core-runtime:${versions.androidxCoreRuntime}"
+    implementation "androidx.collection:collection:${versions.androidxCollection}"
+    implementation "androidx.legacy:legacy-support-core-utils:${versions.legacyCoreUtils}"
+    implementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
+
+    // Workaround for dependency conflict during assembleAndroidTest
+    androidTestImplementation("androidx.arch.core:core-runtime:2.0.1-alpha01")
+
+    // Work around issue with runtime classpath version conflict
+    androidTestImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
+    androidTestImplementation "androidx.legacy:legacy-support-core-utils:${versions.legacyCoreUtils}"
+    androidTestImplementation "androidx.lifecycle:lifecycle-runtime:${versions.lifecycle}"
+
+    androidTestImplementation project(':test_shared')
+    androidTestImplementation "androidx.arch.core:core-testing:${versions.lifecycle}"
+    androidTestImplementation "androidx.test:runner:${versions.test_runner}"
+    androidTestImplementation "androidx.test:rules:${versions.test_rules}"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:${versions.espresso}"
+    androidTestImplementation "androidx.test.espresso:espresso-core:${versions.espresso}"
+    androidTestImplementation "androidx.test.uiautomator:uiautomator:${versions.ui_automator}"
+    androidTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockito_kotlin}"
+    androidTestImplementation "com.squareup.retrofit2:retrofit-mock:${versions.retrofit}"
+    androidTestImplementation "org.mockito:mockito-android:${versions.mockito}"
+    androidTestImplementation "org.mockito:mockito-core:${versions.mockito}"
+}

--- a/test_shared/build.gradle
+++ b/test_shared/build.gradle
@@ -17,6 +17,8 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply from: '../core_dependencies.gradle'
+apply from: '../test_dependencies.gradle'
 
 android {
     compileSdkVersion versions.compileSdk
@@ -28,6 +30,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    packagingOptions {
+        exclude 'META-INF/test_shared_debug.kotlin_module'
     }
 }
 


### PR DESCRIPTION
Gradle figures out where stuff is needed and where to place code in the app bundle.
This also can make incremental builds faster.