### PR TITLE
Moves the injection to the point where the service is started.

### DIFF
--- a/core/src/main/java/io/plaidapp/core/designernews/data/votes/UpvoteStoryService.java
+++ b/core/src/main/java/io/plaidapp/core/designernews/data/votes/UpvoteStoryService.java
@@ -21,6 +21,7 @@ import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import io.plaidapp.core.dagger.designernews.Injector;
 import io.plaidapp.core.designernews.data.api.DesignerNewsService;
 import io.plaidapp.core.designernews.data.login.LoginRepository;
@@ -37,11 +38,16 @@ public class UpvoteStoryService extends IntentService {
 
     public UpvoteStoryService() {
         super("UpvoteStoryService");
-        Injector.inject(this);
     }
 
     @Inject DesignerNewsService service;
     @Inject LoginRepository repository;
+
+    @Override
+    public void onStart(@Nullable Intent intent, int startId) {
+        super.onStart(intent, startId);
+        Injector.inject(this);
+    }
 
     public static void startActionUpvote(@NonNull Context context, long storyId) {
         final Intent intent = new Intent(context, UpvoteStoryService.class);


### PR DESCRIPTION
The injection uses the service as a context, but the context only exists after onStart is called. So moving the injection away from the constructor and in onStart. Fixes #559

P.S. Upvoting doesn't update the UI, but it does trigger the request to the DN API, so don't worry if you don't see anything happening on the screen. 