### PR TITLE
[Bug fix] Save filter doesn't work.

### DIFF
--- a/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
+++ b/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
@@ -235,9 +235,10 @@ class SearchActivity : AppCompatActivity() {
     }
 
     private fun doSave() {
+
         val saveData = Intent()
 
-        saveData.putExtra(Activities.Search.EXTRA_QUERY, searchView.query)
+        saveData.putExtra(Activities.Search.EXTRA_QUERY, searchView.query.toString())
         saveData.putExtra(Activities.Search.EXTRA_SAVE_DRIBBBLE, saveDribbble.isChecked)
         saveData.putExtra(Activities.Search.EXTRA_SAVE_DESIGNER_NEWS, saveDesignerNews.isChecked)
         setResult(Activities.Search.RESULT_CODE_SAVE, saveData)


### PR DESCRIPTION
Root cause: we were passing a CharSequence in the Intent extra and trying to read it as a String. This lead to getting null.