### PR TITLE
Defer initialization of OkHttpClient until first request

### DIFF
--- a/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
@@ -32,8 +32,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 class CoreDataModule {
 
     @Provides
-    fun provideOkHttpClientBuilder(interceptor: HttpLoggingInterceptor): OkHttpClient.Builder =
-        OkHttpClient.Builder().addInterceptor(interceptor)
+    fun provideOkHttpClient(interceptor: HttpLoggingInterceptor): OkHttpClient =
+        OkHttpClient.Builder().addInterceptor(interceptor).build()
 
     @Provides
     fun provideLoggingInterceptor(): HttpLoggingInterceptor =

--- a/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
@@ -32,9 +32,9 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.SOURCE
+import kotlin.annotation.AnnotationRetention.BINARY
 
-@Retention(SOURCE)
+@Retention(BINARY)
 @Qualifier
 private annotation class LocalApi
 

--- a/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
@@ -32,9 +32,9 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationRetention.SOURCE
 
-@Retention(BINARY)
+@Retention(SOURCE)
 @Qualifier
 private annotation class LocalApi
 

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -45,9 +45,9 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.SOURCE
+import kotlin.annotation.AnnotationRetention.BINARY
 
-@Retention(SOURCE)
+@Retention(BINARY)
 @Qualifier
 private annotation class LocalApi
 
@@ -78,8 +78,10 @@ class DesignerNewsDataModule {
 
     @LocalApi
     @Provides
-    fun providePrivateOkHttpClient(upstream: OkHttpClient,
-        tokenHolder: AuthTokenLocalDataSource): OkHttpClient {
+    fun providePrivateOkHttpClient(
+        upstream: OkHttpClient,
+        tokenHolder: AuthTokenLocalDataSource
+    ): OkHttpClient {
         return upstream.newBuilder()
             .addInterceptor(ClientAuthInterceptor(tokenHolder, BuildConfig.DESIGNER_NEWS_CLIENT_ID))
             .build()

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -45,9 +45,9 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationRetention.SOURCE
 
-@Retention(BINARY)
+@Retention(SOURCE)
 @Qualifier
 private annotation class LocalApi
 

--- a/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
@@ -17,6 +17,7 @@
 package io.plaidapp.core.dagger.dribbble
 
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.dagger.CoreDataModule
@@ -26,6 +27,7 @@ import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.search.DribbbleSearchConverter
 import io.plaidapp.core.dribbble.data.search.DribbbleSearchService
 import io.plaidapp.core.dribbble.data.search.SearchRemoteDataSource
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 
 /**
@@ -46,11 +48,13 @@ class DribbbleDataModule {
 
     @Provides
     fun provideDribbbleSearchService(
+        client: Lazy<OkHttpClient>,
         converterFactory: DribbbleSearchConverter.Factory,
         callAdapterFactory: CoroutineCallAdapterFactory
     ): DribbbleSearchService =
         Retrofit.Builder()
             .baseUrl(DribbbleSearchService.ENDPOINT)
+            .callFactory { client.get().newCall(it) }
             .addConverterFactory(converterFactory)
             .addCallAdapterFactory(callAdapterFactory)
             .build()


### PR DESCRIPTION
This uses a pattern of deferred initialization via Retrofit's `Call.Factory` support to allow OkHttpClient (and its initialization) to be deferred until the first network request, and subsequently also move it entirely to a background thread.

I opportunistically cleaned up a couple things here too to either make it more idiomatic DI (intermediate dependencies), and also leverage use of private qualifiers to newBuilder an upstream OkHttpClient as needed rather than keep adding to a builder (which would have added those interceptors to other modules too since the builder's mutable!). This also shared the OkHttpClient instance with the dribbble module, which was otherwise just creating its own instance and doubling the connection pools.