### PR TITLE
[618] Migration from ViewPager to ViewPager2

### DIFF
--- a/about/build.gradle
+++ b/about/build.gradle
@@ -51,4 +51,5 @@ dependencies {
     implementation project(':core')
 
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
+    implementation 'androidx.viewpager2:viewpager2:1.0.0-alpha01'
 }

--- a/about/src/main/java/io/plaidapp/about/ui/AboutActivity.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/AboutActivity.kt
@@ -20,10 +20,10 @@ import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.ContextCompat
-import androidx.viewpager.widget.ViewPager
 import androidx.appcompat.app.AppCompatActivity
 import android.transition.TransitionInflater
 import androidx.core.net.toUri
+import androidx.viewpager2.widget.ViewPager2
 import io.plaidapp.about.R
 import io.plaidapp.about.dagger.inject
 import io.plaidapp.about.ui.adapter.AboutPagerAdapter
@@ -51,7 +51,7 @@ class AboutActivity : AppCompatActivity() {
         setContentView(R.layout.activity_about)
 
         val draggableFrame = findViewById<ElasticDragDismissFrameLayout>(R.id.draggable_frame)
-        val pager = findViewById<ViewPager>(R.id.pager)
+        val pager = findViewById<ViewPager2>(R.id.pager)
         val pageIndicator = findViewById<InkPageIndicator>(R.id.indicator)
 
         inject()
@@ -67,7 +67,6 @@ class AboutActivity : AppCompatActivity() {
 
         pager.apply {
             adapter = AboutPagerAdapter(viewModel.uiModel)
-            pageMargin = resources.getDimensionPixelSize(appR.dimen.spacing_normal)
         }
 
         pageIndicator?.setViewPager(pager)

--- a/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
@@ -49,8 +49,7 @@ internal class AboutPagerAdapter(private val uiModel: AboutUiModel) :
         return when (viewType) {
             0 -> AboutViewHolder(getAboutAppPage(parent))
             1 -> AboutViewHolder(getAboutIconPage(parent))
-            2 -> AboutViewHolder(getAboutLibsPage(parent))
-            else -> throw InvalidParameterException()
+            else -> AboutViewHolder(getAboutLibsPage(parent))
         }
     }
 

--- a/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
+++ b/about/src/main/java/io/plaidapp/about/ui/adapter/AboutPagerAdapter.kt
@@ -16,47 +16,50 @@
 
 package io.plaidapp.about.ui.adapter
 
-import androidx.viewpager.widget.PagerAdapter
-import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
 import io.plaidapp.about.R
-import io.plaidapp.core.util.HtmlUtils
 import io.plaidapp.about.ui.model.AboutUiModel
+import io.plaidapp.core.util.HtmlUtils
 import io.plaidapp.core.util.inflateView
 import java.security.InvalidParameterException
 
 /**
  * Adapter creating and holding on to pages displayed within [io.plaidapp.about.ui.AboutActivity].
  */
-internal class AboutPagerAdapter(private val uiModel: AboutUiModel) : PagerAdapter() {
+internal class AboutPagerAdapter(private val uiModel: AboutUiModel) :
+    RecyclerView.Adapter<AboutPagerAdapter.AboutViewHolder>() {
 
     private var aboutPlaid: View? = null
     private var aboutIcon: View? = null
     private var aboutLibs: View? = null
 
-    override fun instantiateItem(collection: ViewGroup, position: Int): Any {
-        return getPage(position, collection).also {
-            collection.addView(it)
-        }
-    }
-
-    override fun destroyItem(collection: ViewGroup, position: Int, view: Any) {
-        collection.removeView(view as View)
-    }
-
-    override fun getCount() = 3
-
-    override fun isViewFromObject(view: View, obj: Any) = view === obj
-
-    private fun getPage(position: Int, parent: ViewGroup): View {
+    override fun getItemViewType(position: Int): Int {
         return when (position) {
-            0 -> getAboutAppPage(parent)
-            1 -> getAboutIconPage(parent)
-            2 -> getAboutLibsPage(parent)
+            0 -> 0
+            1 -> 1
+            2 -> 2
             else -> throw InvalidParameterException()
         }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AboutViewHolder {
+        return when (viewType) {
+            0 -> AboutViewHolder(getAboutAppPage(parent))
+            1 -> AboutViewHolder(getAboutIconPage(parent))
+            2 -> AboutViewHolder(getAboutLibsPage(parent))
+            else -> throw InvalidParameterException()
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return 3
+    }
+
+    override fun onBindViewHolder(holder: AboutViewHolder, position: Int) {
+        // do nothing
     }
 
     private fun getAboutIconPage(parent: ViewGroup): View {
@@ -86,4 +89,6 @@ internal class AboutPagerAdapter(private val uiModel: AboutUiModel) : PagerAdapt
             aboutLibs = this
         }
     }
+
+    class AboutViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
 }

--- a/about/src/main/java/io/plaidapp/about/ui/widget/InkPageIndicator.java
+++ b/about/src/main/java/io/plaidapp/about/ui/widget/InkPageIndicator.java
@@ -26,23 +26,22 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
+import androidx.viewpager2.widget.ViewPager2;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
 import android.view.animation.Interpolator;
 import androidx.recyclerview.widget.RecyclerView;
-import androidx.viewpager.widget.ViewPager;
-import androidx.viewpager2.widget.ViewPager2;
-import io.plaidapp.about.R;
-import io.plaidapp.core.util.AnimUtils;
 
 import java.util.Arrays;
 
+import io.plaidapp.about.R;
+import io.plaidapp.core.util.AnimUtils;
+
 /**
- * An ink inspired widget for indicating pages in a {@link ViewPager}.
+ * An ink inspired widget for indicating pages in a {@link ViewPager2}.
  */
-public class InkPageIndicator extends View implements ViewPager.OnPageChangeListener,
-                                                      View.OnAttachStateChangeListener {
+public class InkPageIndicator extends View implements View.OnAttachStateChangeListener {
 
     // defaults
     private static final int DEFAULT_DOT_SIZE = 8;                      // dp
@@ -222,43 +221,6 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
         this.selectedColour = selectedColour;
         selectedPaint.setColor(selectedColour);
         invalidate();
-    }
-
-    @Override
-    public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-        if (isAttachedToWindow) {
-            float fraction = positionOffset;
-            int currentPosition = pageChanging ? previousPage : currentPage;
-            int leftDotPosition = position;
-            // when swiping from #2 to #1 ViewPager reports position as 1 and a descending offset
-            // need to convert this into our left-dot-based 'coordinate space'
-            if (currentPosition != position) {
-                fraction = 1f - positionOffset;
-
-                // if user scrolls completely to next page then the position param updates to that
-                // new page but we're not ready to switch our 'current' page yet so adjust for that
-                if (fraction == 1f) {
-                    leftDotPosition = Math.min(currentPosition, position);
-                }
-            }
-            setJoiningFraction(leftDotPosition, fraction);
-        }
-    }
-
-    @Override
-    public void onPageSelected(int position) {
-        if (isAttachedToWindow) {
-            // this is the main event we're interested in!
-            setSelectedPage(position);
-        } else {
-            // when not attached, don't animate the move, just store immediately
-            setCurrentPageImmediate();
-        }
-    }
-
-    @Override
-    public void onPageScrollStateChanged(int state) {
-        // nothing to do
     }
 
     private void setPageCount(int pages) {

--- a/about/src/main/java/io/plaidapp/about/ui/widget/InkPageIndicator.java
+++ b/about/src/main/java/io/plaidapp/about/ui/widget/InkPageIndicator.java
@@ -22,21 +22,21 @@ import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.database.DataSetObserver;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
-import androidx.viewpager.widget.ViewPager;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
 import android.view.animation.Interpolator;
-
-import java.util.Arrays;
-
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.viewpager.widget.ViewPager;
+import androidx.viewpager2.widget.ViewPager2;
 import io.plaidapp.about.R;
 import io.plaidapp.core.util.AnimUtils;
+
+import java.util.Arrays;
 
 /**
  * An ink inspired widget for indicating pages in a {@link ViewPager}.
@@ -71,7 +71,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
     private float dotBottomY;
 
     // ViewPager
-    private ViewPager viewPager;
+    private ViewPager2 viewPager;
 
     // state
     private int pageCount;
@@ -159,14 +159,54 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
         addOnAttachStateChangeListener(this);
     }
 
-    public void setViewPager(ViewPager viewPager) {
+    public void setViewPager(ViewPager2 viewPager) {
         this.viewPager = viewPager;
-        viewPager.addOnPageChangeListener(this);
-        setPageCount(viewPager.getAdapter().getCount());
-        viewPager.getAdapter().registerDataSetObserver(new DataSetObserver() {
+        viewPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+                super.onPageScrolled(position, positionOffset, positionOffsetPixels);
+                if (isAttachedToWindow) {
+                    float fraction = positionOffset;
+                    int currentPosition = pageChanging ? previousPage : currentPage;
+                    int leftDotPosition = position;
+                    // when swiping from #2 to #1 ViewPager reports position as 1 and a descending offset
+                    // need to convert this into our left-dot-based 'coordinate space'
+                    if (currentPosition != position) {
+                        fraction = 1f - positionOffset;
+
+                        // if user scrolls completely to next page then the position param updates to that
+                        // new page but we're not ready to switch our 'current' page yet so adjust for that
+                        if (fraction == 1f) {
+                            leftDotPosition = Math.min(currentPosition, position);
+                        }
+                    }
+                    setJoiningFraction(leftDotPosition, fraction);
+                }
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+                super.onPageSelected(position);
+                if (isAttachedToWindow) {
+                    // this is the main event we're interested in!
+                    setSelectedPage(position);
+                } else {
+                    // when not attached, don't animate the move, just store immediately
+                    setCurrentPageImmediate();
+                }
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+                super.onPageScrollStateChanged(state);
+                // nothing to do
+            }
+        });
+        setPageCount(viewPager.getAdapter().getItemCount());
+        viewPager.getAdapter().registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
             @Override
             public void onChanged() {
-                setPageCount(InkPageIndicator.this.viewPager.getAdapter().getCount());
+                setPageCount(InkPageIndicator.this.viewPager.getAdapter().getItemCount());
             }
         });
         setCurrentPageImmediate();

--- a/about/src/main/java/io/plaidapp/about/ui/widget/InkPageIndicator.java
+++ b/about/src/main/java/io/plaidapp/about/ui/widget/InkPageIndicator.java
@@ -26,17 +26,16 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
-import androidx.viewpager2.widget.ViewPager2;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
 import android.view.animation.Interpolator;
 import androidx.recyclerview.widget.RecyclerView;
-
-import java.util.Arrays;
-
+import androidx.viewpager2.widget.ViewPager2;
 import io.plaidapp.about.R;
 import io.plaidapp.core.util.AnimUtils;
+
+import java.util.Arrays;
 
 /**
  * An ink inspired widget for indicating pages in a {@link ViewPager2}.

--- a/about/src/main/res/layout/about_libs.xml
+++ b/about/src/main/res/layout/about_libs.xml
@@ -21,7 +21,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     tools:showIn="@layout/activity_about">
 
     <!-- we use a parallel view for the background rather than just setting a background on the

--- a/about/src/main/res/layout/activity_about.xml
+++ b/about/src/main/res/layout/activity_about.xml
@@ -27,7 +27,7 @@
     app:dragDismissScale="0.95"
     tools:context=".ui.AboutActivity">
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-beta02'
+        classpath 'com.android.tools.build:gradle:3.4.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Jan 24 11:25:43 PST 2019
+#Tue Feb 26 15:31:28 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixes issue [#618](https://github.com/nickbutcher/plaid/issues/618) - Update the About screen to use the ViewPager2 library

### Issues encountered & feedback
Overall smooth migration. However new `ViewPager2` does not have `pageMargin` variable, so I couldn't figure out how to keep the space between pages.

*This is my first contribution to an open source Android project. Feedback welcomed!

### Steps taken
1. added dependency to `about` module
2. changed `ViewPager` to `ViewPager2` in `activity_about.xml`
3. Modified `AboutActivity.java` to use new view pager
4. Replaced old `PagerAdapter()` extension with `RecyclerView.Adapter` in `AboutPagerAdapter.java` and implemented the required accompanying member functions
5. Removed existing `ViewPager.OnPageChangeListener` implementation in `InkPageIndicator` and replaced it with new `registerOnPageChangeCallback`