### PR TITLE
Moves some Designer News related classes from core to designernews module

### DIFF
--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -31,8 +31,6 @@ import io.plaidapp.core.data.api.DenvelopingConverter
 import io.plaidapp.core.designernews.data.api.ClientAuthInterceptor
 import io.plaidapp.core.designernews.data.api.DesignerNewsSearchConverter
 import io.plaidapp.core.designernews.data.api.DesignerNewsService
-import io.plaidapp.core.designernews.data.comments.CommentsRemoteDataSource
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
 import io.plaidapp.core.designernews.data.database.DesignerNewsDatabase
 import io.plaidapp.core.designernews.data.database.LoggedInUserDao
 import io.plaidapp.core.designernews.data.login.AuthTokenLocalDataSource
@@ -118,8 +116,4 @@ class DesignerNewsDataModule {
     fun provideStoriesRemoteDataSource(service: DesignerNewsService): StoriesRemoteDataSource {
         return StoriesRemoteDataSource.getInstance(service)
     }
-
-    @Provides
-    fun provideCommentsRepository(dataSource: CommentsRemoteDataSource): CommentsRepository =
-        CommentsRepository.getInstance(dataSource)
 }

--- a/core/src/main/java/io/plaidapp/core/designernews/data/api/DesignerNewsService.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/data/api/DesignerNewsService.kt
@@ -23,8 +23,6 @@ import io.plaidapp.core.designernews.data.poststory.model.NewStoryRequest
 import io.plaidapp.core.designernews.data.stories.model.Story
 import io.plaidapp.core.designernews.data.stories.model.StoryResponse
 import io.plaidapp.core.designernews.data.users.model.User
-import io.plaidapp.core.designernews.data.votes.model.UpvoteCommentRequest
-import io.plaidapp.core.designernews.data.votes.model.UpvoteStoryRequest
 import kotlinx.coroutines.Deferred
 import retrofit2.Call
 import retrofit2.Response
@@ -79,18 +77,10 @@ interface DesignerNewsService {
     @POST("api/v2/stories/{id}/upvote")
     fun upvoteStory(@Path("id") storyId: Long): Call<Story>
 
-    @Headers("Content-Type: application/vnd.api+json")
-    @POST("api/v2/upvotes")
-    fun upvoteStoryV2(@Body request: UpvoteStoryRequest): Deferred<Response<Unit>>
-
     @EnvelopePayload("stories")
     @Headers("Content-Type: application/vnd.api+json")
     @POST("api/v2/stories")
     fun postStory(@Body story: NewStoryRequest): Call<List<Story>>
-
-    @Headers("Content-Type: application/vnd.api+json")
-    @POST("api/v2/comment_upvotes")
-    fun upvoteComment(@Body request: UpvoteCommentRequest): Deferred<Response<Unit>>
 
     companion object {
         const val ENDPOINT = "https://www.designernews.co/"

--- a/core/src/test/java/io/plaidapp/core/designernews/TestData.kt
+++ b/core/src/test/java/io/plaidapp/core/designernews/TestData.kt
@@ -16,19 +16,14 @@
 
 package io.plaidapp.core.designernews
 
-import io.plaidapp.core.designernews.data.comments.model.CommentLinksResponse
-import io.plaidapp.core.designernews.data.comments.model.CommentResponse
 import io.plaidapp.core.designernews.data.stories.model.StoryLinks
 import io.plaidapp.core.designernews.data.users.model.User
 import okhttp3.MediaType
 import okhttp3.ResponseBody
-import java.util.GregorianCalendar
 
 /**
  * Test data
  */
-
-const val parentId = 1L
 
 val user = User(
     id = 111L,
@@ -38,34 +33,9 @@ val user = User(
     portraitUrl = "www"
 )
 
-val links = CommentLinksResponse(
-    userId = user.id,
-    story = 999L,
-    parentComment = parentId
-)
+val errorResponseBody = ResponseBody.create(MediaType.parse(""), "Error")!!
 
-val replyResponse1 = CommentResponse(
-    id = 11L,
-    body = "commenty comment",
-    created_at = GregorianCalendar(1988, 1, 1).time,
-    links = links
-)
-
-val replyResponse2 = CommentResponse(
-    id = 12L,
-    body = "commenty comment",
-    created_at = GregorianCalendar(1908, 2, 8).time,
-    links = links
-)
-
-val repliesResponses = listOf(
-    replyResponse1,
-    replyResponse2
-)
-
-val errorResponseBody = ResponseBody.create(MediaType.parse(""), "Error")
-
-val userId = 123L
+const val userId = 123L
 
 val storyLinks = StoryLinks(
     user = userId,

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -54,3 +54,6 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
 }
 
+androidExtensions {
+    experimental = true
+}

--- a/designernews/build.gradle
+++ b/designernews/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:${versions.dagger}"
 }
 
+// enabling experimental for Kotlin parcelize supports
 androidExtensions {
     experimental = true
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.designernews.dagger
+
+import com.google.gson.Gson
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import dagger.Lazy
+import dagger.Module
+import dagger.Provides
+import io.plaidapp.core.BuildConfig
+import io.plaidapp.core.dagger.CoreDataModule
+import io.plaidapp.core.dagger.CoroutinesDispatcherProviderModule
+import io.plaidapp.core.dagger.SharedPreferencesModule
+import io.plaidapp.core.data.api.DenvelopingConverter
+import io.plaidapp.core.designernews.data.api.DesignerNewsService
+import io.plaidapp.core.designernews.data.login.AuthTokenLocalDataSource
+import io.plaidapp.designernews.data.api.ClientAuthInterceptor
+import io.plaidapp.designernews.data.api.DNService
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Qualifier
+import kotlin.annotation.AnnotationRetention.BINARY
+
+@Retention(BINARY)
+@Qualifier
+private annotation class LocalApi
+
+/**
+ * Dagger module to provide data functionality for DesignerNews.
+ */
+@Module(
+    includes = [
+        SharedPreferencesModule::class,
+        CoreDataModule::class,
+        CoroutinesDispatcherProviderModule::class
+    ]
+)
+class DataModule {
+
+    @LocalApi
+    @Provides
+    fun providePrivateOkHttpClient(
+        upstream: OkHttpClient,
+        tokenHolder: AuthTokenLocalDataSource
+    ): OkHttpClient {
+        return upstream.newBuilder()
+            .addInterceptor(ClientAuthInterceptor(tokenHolder, BuildConfig.DESIGNER_NEWS_CLIENT_ID))
+            .build()
+    }
+
+    @Provides
+    fun provideDNService(
+        @LocalApi client: Lazy<OkHttpClient>,
+        gson: Gson
+    ): DNService {
+        return Retrofit.Builder()
+            .baseUrl(DesignerNewsService.ENDPOINT)
+            .callFactory { client.get().newCall(it) }
+            .addConverterFactory(DenvelopingConverter(gson))
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .build()
+            .create(DNService::class.java)
+    }
+}

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
@@ -26,7 +26,6 @@ import io.plaidapp.core.dagger.CoreDataModule
 import io.plaidapp.core.dagger.CoroutinesDispatcherProviderModule
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.data.api.DenvelopingConverter
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
 import io.plaidapp.core.designernews.data.login.AuthTokenLocalDataSource
 import io.plaidapp.designernews.data.api.ClientAuthInterceptor
 import io.plaidapp.designernews.data.api.DNService
@@ -69,7 +68,7 @@ class DataModule {
         gson: Gson
     ): DNService {
         return Retrofit.Builder()
-            .baseUrl(DesignerNewsService.ENDPOINT)
+            .baseUrl(DNService.ENDPOINT)
             .callFactory { client.get().newCall(it) }
             .addConverterFactory(DenvelopingConverter(gson))
             .addConverterFactory(GsonConverterFactory.create(gson))

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
@@ -28,7 +28,7 @@ import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.data.api.DenvelopingConverter
 import io.plaidapp.core.designernews.data.login.AuthTokenLocalDataSource
 import io.plaidapp.designernews.data.api.ClientAuthInterceptor
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -63,17 +63,17 @@ class DataModule {
     }
 
     @Provides
-    fun provideDNService(
+    fun provideDesignerNewsService(
         @LocalApi client: Lazy<OkHttpClient>,
         gson: Gson
-    ): DNService {
+    ): DesignerNewsService {
         return Retrofit.Builder()
-            .baseUrl(DNService.ENDPOINT)
+            .baseUrl(DesignerNewsService.ENDPOINT)
             .callFactory { client.get().newCall(it) }
             .addConverterFactory(DenvelopingConverter(gson))
             .addConverterFactory(GsonConverterFactory.create(gson))
             .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .build()
-            .create(DNService::class.java)
+            .create(DesignerNewsService::class.java)
     }
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
@@ -24,7 +24,7 @@ import io.plaidapp.core.dagger.MarkdownModule
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
 import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.designernews.data.users.UserRemoteDataSource
@@ -93,7 +93,7 @@ class StoryModule(private val storyId: Long, private val activity: StoryActivity
         UserRepository.getInstance(dataSource)
 
     @Provides
-    fun provideCommentsRemoteDataSource(service: DNService): CommentsRemoteDataSource =
+    fun provideCommentsRemoteDataSource(service: DesignerNewsService): CommentsRemoteDataSource =
         CommentsRemoteDataSource.getInstance(service)
 
     @Provides

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
@@ -24,7 +24,7 @@ import io.plaidapp.core.dagger.MarkdownModule
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
+import io.plaidapp.designernews.data.api.DNService
 import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
 import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.designernews.data.users.UserRemoteDataSource
@@ -49,6 +49,7 @@ import io.plaidapp.designernews.ui.story.StoryViewModelFactory
 @Module(
     includes = [CoreDataModule::class,
         DesignerNewsDataModule::class,
+        DataModule::class,
         MarkdownModule::class,
         SharedPreferencesModule::class]
 )
@@ -92,7 +93,7 @@ class StoryModule(private val storyId: Long, private val activity: StoryActivity
         UserRepository.getInstance(dataSource)
 
     @Provides
-    fun provideCommentsRemoteDataSource(service: DesignerNewsService): CommentsRemoteDataSource =
+    fun provideCommentsRemoteDataSource(service: DNService): CommentsRemoteDataSource =
         CommentsRemoteDataSource.getInstance(service)
 
     @Provides

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
@@ -25,7 +25,8 @@ import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.designernews.data.api.DesignerNewsService
-import io.plaidapp.core.designernews.data.comments.CommentsRemoteDataSource
+import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.designernews.data.users.UserRemoteDataSource
 import io.plaidapp.designernews.data.users.UserRepository
 import io.plaidapp.designernews.data.votes.VotesRemoteDataSource
@@ -97,4 +98,8 @@ class StoryModule(private val storyId: Long, private val activity: StoryActivity
     @Provides
     fun provideVotesRepository(remoteDataSource: VotesRemoteDataSource): VotesRepository =
         VotesRepository.getInstance(remoteDataSource)
+
+    @Provides
+    fun provideCommentsRepository(dataSource: CommentsRemoteDataSource): CommentsRepository =
+        CommentsRepository.getInstance(dataSource)
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/api/ClientAuthInterceptor.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/api/ClientAuthInterceptor.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.designernews.data.api
+
+import io.plaidapp.core.designernews.data.login.AuthTokenLocalDataSource
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+/**
+ * An {@see Interceptor} that adds an auth token to requests if one is provided, otherwise
+ * adds a client id.
+ */
+class ClientAuthInterceptor(
+    private val authTokenDataSource: AuthTokenLocalDataSource,
+    private val clientId: String
+) : Interceptor {
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val requestBuilder = chain.request().newBuilder()
+        if (!authTokenDataSource.authToken.isNullOrEmpty()) {
+            requestBuilder.addHeader("Authorization",
+                    "Bearer ${authTokenDataSource.authToken}")
+        } else {
+            val url = chain.request().url().newBuilder()
+                    .addQueryParameter("client_id", clientId).build()
+            requestBuilder.url(url)
+        }
+        return chain.proceed(requestBuilder.build())
+    }
+}

--- a/designernews/src/main/java/io/plaidapp/designernews/data/api/DNService.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/api/DNService.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.api
+package io.plaidapp.designernews.data.api
 
 import io.plaidapp.core.data.api.EnvelopePayload
 import io.plaidapp.core.designernews.data.login.model.AccessToken
@@ -25,6 +25,9 @@ import io.plaidapp.core.designernews.data.stories.model.StoryResponse
 import io.plaidapp.core.designernews.data.users.model.User
 import io.plaidapp.core.designernews.data.votes.model.UpvoteCommentRequest
 import io.plaidapp.core.designernews.data.votes.model.UpvoteStoryRequest
+import io.plaidapp.designernews.data.comments.model.CommentResponse
+import io.plaidapp.designernews.data.comments.model.NewCommentRequest
+import io.plaidapp.designernews.data.comments.model.PostCommentResponse
 import kotlinx.coroutines.Deferred
 import retrofit2.Call
 import retrofit2.Response
@@ -43,7 +46,7 @@ import retrofit2.http.Query
  * v1 docs: https://github.com/layervault/dn_api
  * v2 docs: https://github.com/DesignerNews/dn_api_v2
  */
-interface DesignerNewsService {
+interface DNService {
 
     @EnvelopePayload("stories")
     @GET("api/v2/stories")
@@ -87,6 +90,14 @@ interface DesignerNewsService {
     @Headers("Content-Type: application/vnd.api+json")
     @POST("api/v2/stories")
     fun postStory(@Body story: NewStoryRequest): Call<List<Story>>
+
+    @EnvelopePayload("comments")
+    @GET("api/v2/comments/{ids}")
+    fun getComments(@Path("ids") commentIds: String): Deferred<Response<List<CommentResponse>>>
+
+    @Headers("Content-Type: application/vnd.api+json")
+    @POST("api/v2/comments")
+    fun comment(@Body comment: NewCommentRequest): Deferred<Response<PostCommentResponse>>
 
     @Headers("Content-Type: application/vnd.api+json")
     @POST("api/v2/comment_upvotes")

--- a/designernews/src/main/java/io/plaidapp/designernews/data/api/DNService.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/api/DNService.kt
@@ -17,11 +17,7 @@
 package io.plaidapp.designernews.data.api
 
 import io.plaidapp.core.data.api.EnvelopePayload
-import io.plaidapp.core.designernews.data.login.model.AccessToken
-import io.plaidapp.core.designernews.data.login.model.LoggedInUserResponse
-import io.plaidapp.core.designernews.data.poststory.model.NewStoryRequest
 import io.plaidapp.core.designernews.data.stories.model.Story
-import io.plaidapp.core.designernews.data.stories.model.StoryResponse
 import io.plaidapp.core.designernews.data.users.model.User
 import io.plaidapp.designernews.data.votes.model.UpvoteCommentRequest
 import io.plaidapp.designernews.data.votes.model.UpvoteStoryRequest
@@ -32,13 +28,10 @@ import kotlinx.coroutines.Deferred
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.FieldMap
-import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import retrofit2.http.Path
-import retrofit2.http.Query
 
 /**
  * Models the Designer News API.
@@ -48,35 +41,9 @@ import retrofit2.http.Query
  */
 interface DNService {
 
-    @EnvelopePayload("stories")
-    @GET("api/v2/stories")
-    fun getStories(@Query("page") page: Int?): Deferred<Response<List<StoryResponse>>>
-
-    @EnvelopePayload("stories")
-    @GET("api/v2/stories/{ids}")
-    fun getStories(@Path("ids") commaSeparatedIds: String): Deferred<Response<List<StoryResponse>>>
-
     @EnvelopePayload("users")
     @GET("api/v2/users/{ids}")
     fun getUsers(@Path("ids") userids: String): Deferred<Response<List<User>>>
-
-    @EnvelopePayload("users")
-    @GET("api/v2/me")
-    fun getAuthedUser(): Deferred<Response<List<LoggedInUserResponse>>>
-
-    @FormUrlEncoded
-    @POST("oauth/token")
-    fun login(@FieldMap loginParams: Map<String, String>): Deferred<Response<AccessToken>>
-
-    /**
-     * Search Designer News by scraping website.
-     * Returns a list of story IDs
-     */
-    @GET("search?t=story")
-    fun search(
-        @Query("q") query: String,
-        @Query("p") page: Int?
-    ): Deferred<Response<List<String>>>
 
     @EnvelopePayload("story")
     @POST("api/v2/stories/{id}/upvote")
@@ -85,11 +52,6 @@ interface DNService {
     @Headers("Content-Type: application/vnd.api+json")
     @POST("api/v2/upvotes")
     fun upvoteStoryV2(@Body request: UpvoteStoryRequest): Deferred<Response<Unit>>
-
-    @EnvelopePayload("stories")
-    @Headers("Content-Type: application/vnd.api+json")
-    @POST("api/v2/stories")
-    fun postStory(@Body story: NewStoryRequest): Call<List<Story>>
 
     @EnvelopePayload("comments")
     @GET("api/v2/comments/{ids}")

--- a/designernews/src/main/java/io/plaidapp/designernews/data/api/DNService.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/api/DNService.kt
@@ -23,8 +23,8 @@ import io.plaidapp.core.designernews.data.poststory.model.NewStoryRequest
 import io.plaidapp.core.designernews.data.stories.model.Story
 import io.plaidapp.core.designernews.data.stories.model.StoryResponse
 import io.plaidapp.core.designernews.data.users.model.User
-import io.plaidapp.core.designernews.data.votes.model.UpvoteCommentRequest
-import io.plaidapp.core.designernews.data.votes.model.UpvoteStoryRequest
+import io.plaidapp.designernews.data.votes.model.UpvoteCommentRequest
+import io.plaidapp.designernews.data.votes.model.UpvoteStoryRequest
 import io.plaidapp.designernews.data.comments.model.CommentResponse
 import io.plaidapp.designernews.data.comments.model.NewCommentRequest
 import io.plaidapp.designernews.data.comments.model.PostCommentResponse

--- a/designernews/src/main/java/io/plaidapp/designernews/data/api/DesignerNewsService.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/api/DesignerNewsService.kt
@@ -39,7 +39,7 @@ import retrofit2.http.Path
  * v1 docs: https://github.com/layervault/dn_api
  * v2 docs: https://github.com/DesignerNews/dn_api_v2
  */
-interface DNService {
+interface DesignerNewsService {
 
     @EnvelopePayload("users")
     @GET("api/v2/users/{ids}")

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
@@ -17,16 +17,16 @@
 package io.plaidapp.designernews.data.comments
 
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
-import io.plaidapp.core.designernews.data.comments.model.CommentResponse
-import io.plaidapp.core.designernews.data.comments.model.NewCommentRequest
+import io.plaidapp.designernews.data.comments.model.CommentResponse
+import io.plaidapp.designernews.data.comments.model.NewCommentRequest
 import io.plaidapp.core.util.safeApiCall
+import io.plaidapp.designernews.data.api.DNService
 import java.io.IOException
 
 /**
  * Work with the Designer News API to get comments. The class knows how to construct the requests.
  */
-class CommentsRemoteDataSource(private val service: DesignerNewsService) {
+class CommentsRemoteDataSource(private val service: DNService) {
 
     /**
      * Get a list of comments based on ids from Designer News API.
@@ -95,7 +95,7 @@ class CommentsRemoteDataSource(private val service: DesignerNewsService) {
     companion object {
         @Volatile private var INSTANCE: CommentsRemoteDataSource? = null
 
-        fun getInstance(service: DesignerNewsService): CommentsRemoteDataSource {
+        fun getInstance(service: DNService): CommentsRemoteDataSource {
             return INSTANCE
                 ?: synchronized(this) {
                 INSTANCE

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
@@ -96,10 +96,8 @@ class CommentsRemoteDataSource(private val service: DesignerNewsService) {
         @Volatile private var INSTANCE: CommentsRemoteDataSource? = null
 
         fun getInstance(service: DesignerNewsService): CommentsRemoteDataSource {
-            return INSTANCE
-                ?: synchronized(this) {
-                INSTANCE
-                    ?: CommentsRemoteDataSource(service).also { INSTANCE = it }
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: CommentsRemoteDataSource(service).also { INSTANCE = it }
             }
         }
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
@@ -20,13 +20,13 @@ import io.plaidapp.core.data.Result
 import io.plaidapp.designernews.data.comments.model.CommentResponse
 import io.plaidapp.designernews.data.comments.model.NewCommentRequest
 import io.plaidapp.core.util.safeApiCall
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import java.io.IOException
 
 /**
  * Work with the Designer News API to get comments. The class knows how to construct the requests.
  */
-class CommentsRemoteDataSource(private val service: DNService) {
+class CommentsRemoteDataSource(private val service: DesignerNewsService) {
 
     /**
      * Get a list of comments based on ids from Designer News API.
@@ -95,7 +95,7 @@ class CommentsRemoteDataSource(private val service: DNService) {
     companion object {
         @Volatile private var INSTANCE: CommentsRemoteDataSource? = null
 
-        fun getInstance(service: DNService): CommentsRemoteDataSource {
+        fun getInstance(service: DesignerNewsService): CommentsRemoteDataSource {
             return INSTANCE
                 ?: synchronized(this) {
                 INSTANCE

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments
+package io.plaidapp.designernews.data.comments
 
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.api.DesignerNewsService
@@ -96,8 +96,10 @@ class CommentsRemoteDataSource(private val service: DesignerNewsService) {
         @Volatile private var INSTANCE: CommentsRemoteDataSource? = null
 
         fun getInstance(service: DesignerNewsService): CommentsRemoteDataSource {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: CommentsRemoteDataSource(service).also { INSTANCE = it }
+            return INSTANCE
+                ?: synchronized(this) {
+                INSTANCE
+                    ?: CommentsRemoteDataSource(service).also { INSTANCE = it }
             }
         }
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.designernews.data.comments
 
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.comments.model.CommentResponse
+import io.plaidapp.designernews.data.comments.model.CommentResponse
 
 /**
  * Class that knows how to get and store Designer News comments.

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments
+package io.plaidapp.designernews.data.comments
 
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.comments.model.CommentResponse
@@ -71,7 +71,8 @@ class CommentsRepository(private val remoteDataSource: CommentsRemoteDataSource)
             remoteDataSource: CommentsRemoteDataSource
         ): CommentsRepository {
             return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: CommentsRepository(remoteDataSource).also { INSTANCE = it }
+                INSTANCE
+                    ?: CommentsRepository(remoteDataSource).also { INSTANCE = it }
             }
         }
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
@@ -71,8 +71,7 @@ class CommentsRepository(private val remoteDataSource: CommentsRemoteDataSource)
             remoteDataSource: CommentsRemoteDataSource
         ): CommentsRepository {
             return INSTANCE ?: synchronized(this) {
-                INSTANCE
-                    ?: CommentsRepository(remoteDataSource).also { INSTANCE = it }
+                INSTANCE ?: CommentsRepository(remoteDataSource).also { INSTANCE = it }
             }
         }
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/CommentLinksResponse.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/CommentLinksResponse.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments.model
+package io.plaidapp.designernews.data.comments.model
 
 import android.os.Parcelable
 import com.google.gson.annotations.SerializedName

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/CommentResponse.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/CommentResponse.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments.model
+package io.plaidapp.designernews.data.comments.model
 
 import com.google.gson.annotations.SerializedName
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/NewCommentRequest.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/NewCommentRequest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments.model
+package io.plaidapp.designernews.data.comments.model
 
 import com.google.gson.annotations.SerializedName
 
@@ -24,7 +24,12 @@ class NewCommentRequest(
     story: String?,
     user: String,
     @SerializedName("comments") val comment: PostCommentRequest =
-        PostCommentRequest(CommentData(body), CommentLinks(parent_comment, story, user))
+        PostCommentRequest(
+            CommentData(
+                body
+            ),
+            CommentLinks(parent_comment, story, user)
+        )
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/PostCommentResponse.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/model/PostCommentResponse.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments.model
+package io.plaidapp.designernews.data.comments.model
 
 import com.google.gson.annotations.SerializedName
 

--- a/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRemoteDataSource.kt
@@ -17,16 +17,16 @@
 package io.plaidapp.designernews.data.users
 
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
 import io.plaidapp.core.designernews.data.users.model.User
 import io.plaidapp.core.util.safeApiCall
+import io.plaidapp.designernews.data.api.DNService
 import java.io.IOException
 import javax.inject.Inject
 
 /**
  * Class that requests users from the service.
  */
-class UserRemoteDataSource @Inject constructor(private val service: DesignerNewsService) {
+class UserRemoteDataSource @Inject constructor(private val service: DNService) {
 
     suspend fun getUsers(userIds: List<Long>) = safeApiCall(
         call = { requestGetUsers(userIds) },

--- a/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRemoteDataSource.kt
@@ -19,14 +19,14 @@ package io.plaidapp.designernews.data.users
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.users.model.User
 import io.plaidapp.core.util.safeApiCall
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import java.io.IOException
 import javax.inject.Inject
 
 /**
  * Class that requests users from the service.
  */
-class UserRemoteDataSource @Inject constructor(private val service: DNService) {
+class UserRemoteDataSource @Inject constructor(private val service: DesignerNewsService) {
 
     suspend fun getUsers(userIds: List<Long>) = safeApiCall(
         call = { requestGetUsers(userIds) },

--- a/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
@@ -20,14 +20,14 @@ import io.plaidapp.core.data.Result
 import io.plaidapp.designernews.data.votes.model.UpvoteCommentRequest
 import io.plaidapp.designernews.data.votes.model.UpvoteStoryRequest
 import io.plaidapp.core.util.safeApiCall
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import java.io.IOException
 import javax.inject.Inject
 
 /**
  * Class that works with the Designer News API to up/down vote comments and stories
  */
-class VotesRemoteDataSource @Inject constructor(private val service: DNService) {
+class VotesRemoteDataSource @Inject constructor(private val service: DesignerNewsService) {
 
     suspend fun upvoteStory(storyId: Long, userId: Long) = safeApiCall(
         call = { requestUpvoteStory(storyId, userId) },

--- a/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
@@ -54,8 +54,7 @@ class VotesRemoteDataSource @Inject constructor(private val service: DesignerNew
     )
 
     private suspend fun requestUpvoteComment(commentId: Long, userId: Long): Result<Unit> {
-        val request =
-            UpvoteCommentRequest(commentId, userId)
+        val request = UpvoteCommentRequest(commentId, userId)
         val response = service.upvoteComment(request).await()
         return if (response.isSuccessful) {
             Result.Success(Unit)

--- a/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSource.kt
@@ -17,17 +17,17 @@
 package io.plaidapp.designernews.data.votes
 
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
-import io.plaidapp.core.designernews.data.votes.model.UpvoteCommentRequest
-import io.plaidapp.core.designernews.data.votes.model.UpvoteStoryRequest
+import io.plaidapp.designernews.data.votes.model.UpvoteCommentRequest
+import io.plaidapp.designernews.data.votes.model.UpvoteStoryRequest
 import io.plaidapp.core.util.safeApiCall
+import io.plaidapp.designernews.data.api.DNService
 import java.io.IOException
 import javax.inject.Inject
 
 /**
  * Class that works with the Designer News API to up/down vote comments and stories
  */
-class VotesRemoteDataSource @Inject constructor(private val service: DesignerNewsService) {
+class VotesRemoteDataSource @Inject constructor(private val service: DNService) {
 
     suspend fun upvoteStory(storyId: Long, userId: Long) = safeApiCall(
         call = { requestUpvoteStory(storyId, userId) },
@@ -54,7 +54,8 @@ class VotesRemoteDataSource @Inject constructor(private val service: DesignerNew
     )
 
     private suspend fun requestUpvoteComment(commentId: Long, userId: Long): Result<Unit> {
-        val request = UpvoteCommentRequest(commentId, userId)
+        val request =
+            UpvoteCommentRequest(commentId, userId)
         val response = service.upvoteComment(request).await()
         return if (response.isSuccessful) {
             Result.Success(Unit)

--- a/designernews/src/main/java/io/plaidapp/designernews/data/votes/model/UpvoteCommentRequest.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/votes/model/UpvoteCommentRequest.kt
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.votes.model
+package io.plaidapp.designernews.data.votes.model
 
 import com.google.gson.annotations.SerializedName
 
 class UpvoteCommentRequest(
     commentId: Long,
     userId: Long,
-    @SerializedName("comment_upvotes") val upvote: UpvoteComment = UpvoteComment(CommentVoteLinks(commentId, userId))
+    @SerializedName("comment_upvotes") val upvote: UpvoteComment = UpvoteComment(
+        CommentVoteLinks(commentId, userId)
+    )
 )
 
 data class UpvoteComment(@SerializedName("links") val voteLinks: CommentVoteLinks)

--- a/designernews/src/main/java/io/plaidapp/designernews/data/votes/model/UpvoteStoryRequest.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/votes/model/UpvoteStoryRequest.kt
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.votes.model
+package io.plaidapp.designernews.data.votes.model
 
 import com.google.gson.annotations.SerializedName
 
 class UpvoteStoryRequest(
     storyId: Long,
     userId: Long,
-    @SerializedName("upvotes") val upvote: UpvoteStory = UpvoteStory(StoryVoteLinks(storyId, userId))
+    @SerializedName("upvotes") val upvote: UpvoteStory = UpvoteStory(
+        StoryVoteLinks(storyId, userId)
+    )
 )
 
 data class UpvoteStory(@SerializedName("links") val voteLinks: StoryVoteLinks)

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesUseCase.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesUseCase.kt
@@ -18,8 +18,8 @@ package io.plaidapp.designernews.domain
 
 import io.plaidapp.core.data.Result
 import io.plaidapp.designernews.data.comments.CommentsRepository
-import io.plaidapp.core.designernews.data.comments.model.CommentResponse
-import io.plaidapp.core.designernews.data.comments.model.toCommentsWithReplies
+import io.plaidapp.designernews.data.comments.model.CommentResponse
+import io.plaidapp.designernews.data.comments.model.toCommentsWithReplies
 import io.plaidapp.core.designernews.domain.model.CommentWithReplies
 import java.io.IOException
 import javax.inject.Inject

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesUseCase.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesUseCase.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.designernews.domain
 
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.core.designernews.data.comments.model.CommentResponse
 import io.plaidapp.core.designernews.data.comments.model.toCommentsWithReplies
 import io.plaidapp.core.designernews.domain.model.CommentWithReplies

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/PostReplyUseCase.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/PostReplyUseCase.kt
@@ -18,7 +18,7 @@ package io.plaidapp.designernews.domain
 
 import io.plaidapp.core.data.Result
 import io.plaidapp.designernews.data.comments.CommentsRepository
-import io.plaidapp.core.designernews.data.comments.model.toCommentWithNoReplies
+import io.plaidapp.designernews.data.comments.model.toCommentWithNoReplies
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.domain.model.Comment
 import io.plaidapp.core.util.exhaustive

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/PostReplyUseCase.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/PostReplyUseCase.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.designernews.domain
 
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.core.designernews.data.comments.model.toCommentWithNoReplies
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.domain.model.Comment

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/PostStoryCommentUseCase.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/PostStoryCommentUseCase.kt
@@ -18,7 +18,7 @@ package io.plaidapp.designernews.domain
 
 import io.plaidapp.core.data.Result
 import io.plaidapp.designernews.data.comments.CommentsRepository
-import io.plaidapp.core.designernews.data.comments.model.toCommentWithNoReplies
+import io.plaidapp.designernews.data.comments.model.toCommentWithNoReplies
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.domain.model.Comment
 import io.plaidapp.core.util.exhaustive

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/PostStoryCommentUseCase.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/PostStoryCommentUseCase.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.designernews.domain
 
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.core.designernews.data.comments.model.toCommentWithNoReplies
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.domain.model.Comment

--- a/designernews/src/test/java/io/plaidapp/designernews/TestData.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/TestData.kt
@@ -16,8 +16,8 @@
 
 package io.plaidapp.designernews
 
-import io.plaidapp.core.designernews.data.comments.model.CommentLinksResponse
-import io.plaidapp.core.designernews.data.comments.model.CommentResponse
+import io.plaidapp.designernews.data.comments.model.CommentLinksResponse
+import io.plaidapp.designernews.data.comments.model.CommentResponse
 import io.plaidapp.core.designernews.data.stories.model.StoryLinks
 import io.plaidapp.core.designernews.data.login.model.LoggedInUser
 import io.plaidapp.core.designernews.data.users.model.User

--- a/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
@@ -20,10 +20,10 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
-import io.plaidapp.core.designernews.data.comments.model.CommentResponse
-import io.plaidapp.core.designernews.data.comments.model.NewCommentRequest
-import io.plaidapp.core.designernews.data.comments.model.PostCommentResponse
+import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.comments.model.CommentResponse
+import io.plaidapp.designernews.data.comments.model.NewCommentRequest
+import io.plaidapp.designernews.data.comments.model.PostCommentResponse
 import io.plaidapp.designernews.errorResponseBody
 import io.plaidapp.designernews.repliesResponses
 import io.plaidapp.designernews.replyResponse1
@@ -43,7 +43,7 @@ class CommentsRemoteDataSourceTest {
 
     private val body = "Plaid is awesome"
 
-    private val service: DesignerNewsService = mock()
+    private val service: DNService = mock()
     private val dataSource =
         io.plaidapp.designernews.data.comments.CommentsRemoteDataSource(service)
 
@@ -128,7 +128,8 @@ class CommentsRemoteDataSourceTest {
     @Test
     fun comment_whenException() = runBlocking {
         // Given that the service throws an exception
-        val request = NewCommentRequest(body, "11", null, "111")
+        val request =
+            NewCommentRequest(body, "11", null, "111")
         doAnswer { throw UnknownHostException() }
             .whenever(service).comment(request)
 
@@ -142,8 +143,13 @@ class CommentsRemoteDataSourceTest {
     @Test
     fun comment_withNoComments() = runBlocking {
         // Given a response returned for a request
-        val response = Response.success(PostCommentResponse(emptyList()))
-        val request = NewCommentRequest(body, "11", null, "111")
+        val response = Response.success(
+            PostCommentResponse(
+                emptyList()
+            )
+        )
+        val request =
+            NewCommentRequest(body, "11", null, "111")
         whenever(service.comment(request)).thenReturn(CompletableDeferred(response))
 
         // When adding a comment
@@ -159,7 +165,8 @@ class CommentsRemoteDataSourceTest {
         val response = Response.success(
             PostCommentResponse(listOf(replyResponse1))
         )
-        val request = NewCommentRequest(body, "11", null, "111")
+        val request =
+            NewCommentRequest(body, "11", null, "111")
         whenever(service.comment(request)).thenReturn(CompletableDeferred(response))
 
         // When adding a comment

--- a/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments
+package io.plaidapp.designernews.data.comments
 
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
@@ -24,9 +24,9 @@ import io.plaidapp.core.designernews.data.api.DesignerNewsService
 import io.plaidapp.core.designernews.data.comments.model.CommentResponse
 import io.plaidapp.core.designernews.data.comments.model.NewCommentRequest
 import io.plaidapp.core.designernews.data.comments.model.PostCommentResponse
-import io.plaidapp.core.designernews.errorResponseBody
-import io.plaidapp.core.designernews.repliesResponses
-import io.plaidapp.core.designernews.replyResponse1
+import io.plaidapp.designernews.errorResponseBody
+import io.plaidapp.designernews.repliesResponses
+import io.plaidapp.designernews.replyResponse1
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -44,7 +44,8 @@ class CommentsRemoteDataSourceTest {
     private val body = "Plaid is awesome"
 
     private val service: DesignerNewsService = mock()
-    private val dataSource = CommentsRemoteDataSource(service)
+    private val dataSource =
+        io.plaidapp.designernews.data.comments.CommentsRemoteDataSource(service)
 
     @Test
     fun getComments_whenRequestSuccessful() = runBlocking {

--- a/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
@@ -44,8 +44,7 @@ class CommentsRemoteDataSourceTest {
     private val body = "Plaid is awesome"
 
     private val service: DesignerNewsService = mock()
-    private val dataSource =
-        io.plaidapp.designernews.data.comments.CommentsRemoteDataSource(service)
+    private val dataSource = CommentsRemoteDataSource(service)
 
     @Test
     fun getComments_whenRequestSuccessful() = runBlocking {
@@ -128,8 +127,7 @@ class CommentsRemoteDataSourceTest {
     @Test
     fun comment_whenException() = runBlocking {
         // Given that the service throws an exception
-        val request =
-            NewCommentRequest(body, "11", null, "111")
+        val request = NewCommentRequest(body, "11", null, "111")
         doAnswer { throw UnknownHostException() }
             .whenever(service).comment(request)
 
@@ -148,8 +146,7 @@ class CommentsRemoteDataSourceTest {
                 emptyList()
             )
         )
-        val request =
-            NewCommentRequest(body, "11", null, "111")
+        val request = NewCommentRequest(body, "11", null, "111")
         whenever(service.comment(request)).thenReturn(CompletableDeferred(response))
 
         // When adding a comment
@@ -165,8 +162,7 @@ class CommentsRemoteDataSourceTest {
         val response = Response.success(
             PostCommentResponse(listOf(replyResponse1))
         )
-        val request =
-            NewCommentRequest(body, "11", null, "111")
+        val request = NewCommentRequest(body, "11", null, "111")
         whenever(service.comment(request)).thenReturn(CompletableDeferred(response))
 
         // When adding a comment

--- a/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSourceTest.kt
@@ -20,7 +20,7 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.comments.model.CommentResponse
 import io.plaidapp.designernews.data.comments.model.NewCommentRequest
 import io.plaidapp.designernews.data.comments.model.PostCommentResponse
@@ -43,7 +43,7 @@ class CommentsRemoteDataSourceTest {
 
     private val body = "Plaid is awesome"
 
-    private val service: DNService = mock()
+    private val service: DesignerNewsService = mock()
     private val dataSource =
         io.plaidapp.designernews.data.comments.CommentsRemoteDataSource(service)
 

--- a/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRepositoryTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/comments/CommentsRepositoryTest.kt
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package io.plaidapp.core.designernews.data.comments
+package io.plaidapp.designernews.data.comments
 
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.repliesResponses
-import io.plaidapp.core.designernews.replyResponse1
+import io.plaidapp.designernews.repliesResponses
+import io.plaidapp.designernews.replyResponse1
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/designernews/src/test/java/io/plaidapp/designernews/data/users/UserRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/users/UserRemoteDataSourceTest.kt
@@ -21,8 +21,8 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
 import io.plaidapp.core.designernews.data.users.model.User
+import io.plaidapp.designernews.data.api.DNService
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import okhttp3.MediaType
@@ -54,7 +54,7 @@ class UserRemoteDataSourceTest {
     private val users = listOf(user1, user2)
     private val errorResponseBody = ResponseBody.create(MediaType.parse(""), "Error")
 
-    private val service: DesignerNewsService = mock()
+    private val service: DNService = mock()
     private val dataSource = UserRemoteDataSource(service)
 
     @Test

--- a/designernews/src/test/java/io/plaidapp/designernews/data/users/UserRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/users/UserRemoteDataSourceTest.kt
@@ -22,7 +22,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.users.model.User
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import okhttp3.MediaType
@@ -54,7 +54,7 @@ class UserRemoteDataSourceTest {
     private val users = listOf(user1, user2)
     private val errorResponseBody = ResponseBody.create(MediaType.parse(""), "Error")
 
-    private val service: DNService = mock()
+    private val service: DesignerNewsService = mock()
     private val dataSource = UserRemoteDataSource(service)
 
     @Test

--- a/designernews/src/test/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSourceTest.kt
@@ -21,7 +21,7 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.errorResponseBody
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
@@ -40,7 +40,7 @@ class VotesRemoteDataSourceTest {
     private val storyId = 1345L
     private val commentId = 435L
 
-    private val service: DNService = mock()
+    private val service: DesignerNewsService = mock()
     private val dataSource = VotesRemoteDataSource(service)
 
     @Test

--- a/designernews/src/test/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSourceTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/data/votes/VotesRemoteDataSourceTest.kt
@@ -21,7 +21,7 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
+import io.plaidapp.designernews.data.api.DNService
 import io.plaidapp.designernews.errorResponseBody
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
@@ -40,7 +40,7 @@ class VotesRemoteDataSourceTest {
     private val storyId = 1345L
     private val commentId = 435L
 
-    private val service: DesignerNewsService = mock()
+    private val service: DNService = mock()
     private val dataSource = VotesRemoteDataSource(service)
 
     @Test

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
@@ -23,8 +23,9 @@ import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
 import io.plaidapp.designernews.data.comments.CommentsRepository
-import io.plaidapp.core.designernews.data.comments.model.CommentResponse
+import io.plaidapp.designernews.data.comments.model.CommentResponse
 import io.plaidapp.core.designernews.data.users.model.User
+import io.plaidapp.designernews.data.api.DNService
 import io.plaidapp.designernews.data.users.UserRemoteDataSource
 import io.plaidapp.designernews.data.users.UserRepository
 import io.plaidapp.designernews.errorResponseBody
@@ -50,12 +51,13 @@ import retrofit2.Response
  * are mocked. Everything else uses real implementation.
  */
 class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
-    private val service: DesignerNewsService = mock()
+    private val service: DNService = mock()
+    private val designerNewsService: DesignerNewsService = mock()
     private val dataSource =
         CommentsRemoteDataSource(service)
     private val commentsRepository =
         CommentsRepository(dataSource)
-    private val userRepository = UserRepository(UserRemoteDataSource(service))
+    private val userRepository = UserRepository(UserRemoteDataSource(designerNewsService))
     private val repository: GetCommentsWithRepliesAndUsersUseCase = GetCommentsWithRepliesAndUsersUseCase(
         GetCommentsWithRepliesUseCase(commentsRepository),
         userRepository

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
@@ -20,12 +20,11 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
 import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.designernews.data.comments.model.CommentResponse
 import io.plaidapp.core.designernews.data.users.model.User
-import io.plaidapp.designernews.data.api.DNService
+import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.users.UserRemoteDataSource
 import io.plaidapp.designernews.data.users.UserRepository
 import io.plaidapp.designernews.errorResponseBody
@@ -51,7 +50,7 @@ import retrofit2.Response
  * are mocked. Everything else uses real implementation.
  */
 class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
-    private val service: DNService = mock()
+    private val service: DesignerNewsService = mock()
     private val dataSource = CommentsRemoteDataSource(service)
     private val commentsRepository = CommentsRepository(dataSource)
     private val userRepository = UserRepository(UserRemoteDataSource(service))

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
@@ -21,8 +21,8 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.designernews.data.api.DesignerNewsService
-import io.plaidapp.core.designernews.data.comments.CommentsRemoteDataSource
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
+import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.core.designernews.data.comments.model.CommentResponse
 import io.plaidapp.core.designernews.data.users.model.User
 import io.plaidapp.designernews.data.users.UserRemoteDataSource
@@ -51,8 +51,10 @@ import retrofit2.Response
  */
 class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
     private val service: DesignerNewsService = mock()
-    private val dataSource = CommentsRemoteDataSource(service)
-    private val commentsRepository = CommentsRepository(dataSource)
+    private val dataSource =
+        CommentsRemoteDataSource(service)
+    private val commentsRepository =
+        CommentsRepository(dataSource)
     private val userRepository = UserRepository(UserRemoteDataSource(service))
     private val repository: GetCommentsWithRepliesAndUsersUseCase = GetCommentsWithRepliesAndUsersUseCase(
         GetCommentsWithRepliesUseCase(commentsRepository),

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesAndUsersUseCaseIntegrationTest.kt
@@ -52,12 +52,9 @@ import retrofit2.Response
  */
 class GetCommentsWithRepliesAndUsersUseCaseIntegrationTest {
     private val service: DNService = mock()
-    private val designerNewsService: DesignerNewsService = mock()
-    private val dataSource =
-        CommentsRemoteDataSource(service)
-    private val commentsRepository =
-        CommentsRepository(dataSource)
-    private val userRepository = UserRepository(UserRemoteDataSource(designerNewsService))
+    private val dataSource = CommentsRemoteDataSource(service)
+    private val commentsRepository = CommentsRepository(dataSource)
+    private val userRepository = UserRepository(UserRemoteDataSource(service))
     private val repository: GetCommentsWithRepliesAndUsersUseCase = GetCommentsWithRepliesAndUsersUseCase(
         GetCommentsWithRepliesUseCase(commentsRepository),
         userRepository

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesUseCaseTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/GetCommentsWithRepliesUseCaseTest.kt
@@ -20,7 +20,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.designernews.parentCommentResponse
 import io.plaidapp.designernews.parentCommentWithReplies
 import io.plaidapp.designernews.parentCommentWithRepliesWithoutReplies

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/PostReplyUseCaseTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/PostReplyUseCaseTest.kt
@@ -19,7 +19,7 @@ package io.plaidapp.designernews.domain
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.domain.model.Comment
 import io.plaidapp.designernews.loggedInUser

--- a/designernews/src/test/java/io/plaidapp/designernews/domain/PostStoryCommentUseCaseTest.kt
+++ b/designernews/src/test/java/io/plaidapp/designernews/domain/PostStoryCommentUseCaseTest.kt
@@ -19,7 +19,7 @@ package io.plaidapp.designernews.domain
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.plaidapp.core.data.Result
-import io.plaidapp.core.designernews.data.comments.CommentsRepository
+import io.plaidapp.designernews.data.comments.CommentsRepository
 import io.plaidapp.core.designernews.data.login.LoginRepository
 import io.plaidapp.core.designernews.domain.model.Comment
 import io.plaidapp.designernews.loggedInUser


### PR DESCRIPTION
Interesting changes:
* Part of the `core.DesignerNewsService` is moved to `designernews.DesignerNewsService`
* `designernews` module now also has a Dagger `DataModule`