### PR TITLE
[SECURITY] Resolve Dependencies over HTTPS

### DIFF
--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,6 +1,6 @@
 repositories {
     maven {
-        url "http://maven.google.com"
+        url "https://maven.google.com"
         content {
             includeGroupByRegex "com\\.android.*"
             includeGroupByRegex "androidx.*"
@@ -66,7 +66,7 @@ repositories {
     }
 
     maven {
-        url 'http://dl.bintray.com/kotlin/kotlin-eap'
+        url 'https://dl.bintray.com/kotlin/kotlin-eap'
         content {
             includeGroupByRegex "org\\.jetbrains.*"
         }


### PR DESCRIPTION
Resolves a security vulnerability where artifacts would be resolved over HTTP instead of HTTPS.

[CWE-829: Inclusion of Functionality from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html)
[CWE-494: Download of Code Without Integrity Check](https://cwe.mitre.org/data/definitions/494.html)

The build files indicate that this project is resolving dependencies over HTTP instead of HTTPS. Any of these artifacts could have been MITM to maliciously compromise them and infect the build artifacts that were produced. Additionally, if any of these JARs or other dependencies were compromised, any developers using these could continue to be infected past updating to fix this.

This vulnerability has a CVSS v3.0 Base Score of 8.1/10
https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H

### This isn't just theoretical
POC code has existed since 2014 to maliciously compromise a JAR file inflight.
See:
* https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/
* https://github.com/mveytsman/dilettante

### MITM Attacks Increasingly Common
See:
* https://serverfault.com/a/153065
* https://security.stackexchange.com/a/12050
* [Comcast continues to inject its own code into websites you visit](https://thenextweb.com/insights/2017/12/11/comcast-continues-to-inject-its-own-code-into-websites-you-visit/#) (over HTTP)

### Further Advice

If your CI pipeline caches artifacts between builds, compromised artifacts can remain there after this is resolved. I advise clearing those caches after this is merged.

Looks Like Circle CI doesn't but if you have another CI provider, please delete that cache.
https://github.com/nickbutcher/plaid/blob/40ee40da12e39bb949d5996f96464eb794d9fad3/.circleci/config.yml#L28-L37