### PR TITLE
Refactor Dribbble Shot feature to use UiModel

### DIFF
--- a/core/src/main/java/io/plaidapp/core/dribbble/data/api/model/Images.kt
+++ b/core/src/main/java/io/plaidapp/core/dribbble/data/api/model/Images.kt
@@ -16,8 +16,10 @@
 
 package io.plaidapp.core.dribbble.data.api.model
 
+import android.os.Parcelable
 import io.plaidapp.core.dribbble.data.api.model.Images.ImageSize.NORMAL_IMAGE_SIZE
 import io.plaidapp.core.dribbble.data.api.model.Images.ImageSize.TWO_X_IMAGE_SIZE
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Models links to the various quality of images of a shot. One of [hidpi] or [normal] must be
@@ -37,7 +39,8 @@ data class Images(
         return if (hidpi != null) TWO_X_IMAGE_SIZE else NORMAL_IMAGE_SIZE
     }
 
-    enum class ImageSize(val width: Int, val height: Int) {
+    @Parcelize
+    enum class ImageSize(val width: Int, val height: Int) : Parcelable {
         NORMAL_IMAGE_SIZE(400, 300),
         TWO_X_IMAGE_SIZE(800, 600);
 

--- a/core/src/main/java/io/plaidapp/core/util/BindingAdapters.kt
+++ b/core/src/main/java/io/plaidapp/core/util/BindingAdapters.kt
@@ -16,12 +16,14 @@
 
 package io.plaidapp.core.util
 
-import androidx.databinding.BindingAdapter
+import android.graphics.drawable.Drawable
 import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.ImageView
+import androidx.databinding.BindingAdapter
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import com.bumptech.glide.request.RequestListener
 import io.plaidapp.core.util.glide.GlideApp
 
 @BindingAdapter("goneUnless")
@@ -42,14 +44,27 @@ fun bindVisibleUnless(view: View, visible: Boolean) {
     }
 }
 
-@BindingAdapter("imageUrl", "placeholder", "circleCrop", "crossFade", requireAll = false)
+@BindingAdapter(
+    "imageUrl",
+    "imagePlaceholder",
+    "circleCropImage",
+    "crossFadeImage",
+    "overrideImageWidth",
+    "overrideImageHeight",
+    "imageLoadListener",
+    requireAll = false
+)
 fun bindImage(
     imageView: ImageView,
     imageUrl: String?,
     placeholder: Int? = null,
     circleCrop: Boolean? = false,
-    crossFade: Boolean? = false
+    crossFade: Boolean? = false,
+    overrideWidth: Int? = null,
+    overrideHeight: Int? = null,
+    listener: RequestListener<Drawable>?
 ) {
+    if (imageUrl == null) return
     var request = GlideApp.with(imageView.context).load(imageUrl)
     if (placeholder != null) {
         request = request.placeholder(placeholder)
@@ -59,6 +74,12 @@ fun bindImage(
     }
     if (crossFade == true) {
         request = request.transition(DrawableTransitionOptions.withCrossFade())
+    }
+    if (overrideWidth != null && overrideHeight != null) {
+        request = request.override(overrideWidth, overrideHeight)
+    }
+    if (listener != null) {
+        request = request.listener(listener)
     }
     request.into(imageView)
 }

--- a/designernews/src/main/res/layout/toast_logged_in_confirmation.xml
+++ b/designernews/src/main/res/layout/toast_logged_in_confirmation.xml
@@ -55,9 +55,9 @@
                     android:layout_margin="@dimen/padding_normal"
                     android:layout_rowSpan="2"
                     app:imageUrl="@{uiModel.portraitUrl}"
-                    app:placeholder="@{appR.drawable.avatar_placeholder}"
-                    app:circleCrop="@{true}"
-                    app:crossFade="@{true}"/>
+                    app:imagePlaceholder="@{appR.drawable.avatar_placeholder}"
+                    app:circleCropImage="@{true}"
+                    app:crossFadeImage="@{true}"/>
 
             <io.plaidapp.core.ui.widget.BaselineGridTextView
                     android:layout_marginEnd="@dimen/padding_normal"

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -25,7 +25,9 @@ import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
 import io.plaidapp.core.util.FileAuthority
+import io.plaidapp.core.util.HtmlParser
 import io.plaidapp.dribbble.BuildConfig
+import io.plaidapp.dribbble.domain.CreateShotUiModelUseCase
 import io.plaidapp.dribbble.domain.GetShareShotInfoUseCase
 import io.plaidapp.dribbble.ui.shot.ShotActivity
 import io.plaidapp.dribbble.ui.shot.ShotViewModel
@@ -55,14 +57,19 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     }
 
     @Provides
+    fun htmlParser() = HtmlParser()
+
+    @Provides
     fun shotViewModelFactory(
         shotsRepository: ShotsRepository,
+        createShotUiModelUseCase: CreateShotUiModelUseCase,
         shareShotInfoUseCase: GetShareShotInfoUseCase,
         coroutinesDispatcherProvider: CoroutinesDispatcherProvider
     ): ShotViewModelFactory {
         return ShotViewModelFactory(
             shotId,
             shotsRepository,
+            createShotUiModelUseCase,
             shareShotInfoUseCase,
             coroutinesDispatcherProvider
         )

--- a/dribbble/src/main/java/io/plaidapp/dribbble/domain/CreateShotUiModelUseCase.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/domain/CreateShotUiModelUseCase.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.dribbble.domain
+
+import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import io.plaidapp.core.dribbble.data.api.model.Shot
+import io.plaidapp.core.util.HtmlParser
+import io.plaidapp.dribbble.ui.shot.ShotStyler
+import io.plaidapp.dribbble.ui.shot.ShotUiModel
+import kotlinx.coroutines.withContext
+import java.text.NumberFormat
+import javax.inject.Inject
+
+class CreateShotUiModelUseCase @Inject constructor(
+    private val htmlParser: HtmlParser,
+    private val styler: ShotStyler,
+    private val dispatcherProvider: CoroutinesDispatcherProvider
+) {
+
+    suspend operator fun invoke(model: Shot): ShotUiModel = withContext(dispatcherProvider.computation) {
+
+        val desc = htmlParser.parse(model.description, styler.linkColors, styler.highlightColor)
+        val numberFormatter = NumberFormat.getInstance(styler.locale)
+
+        return@withContext ShotUiModel(
+            id = model.id,
+            title = model.title,
+            url = model.htmlUrl,
+            formattedDescription = desc,
+            imageUrl = model.images.best(),
+            imageSize = model.images.bestSize(),
+            likesCount = model.likesCount,
+            formattedLikesCount = numberFormatter.format(model.likesCount),
+            viewsCount = model.viewsCount,
+            formattedViewsCount = numberFormatter.format(model.viewsCount),
+            createdAt = model.createdAt,
+            userName = model.user.name.toLowerCase(),
+            userAvatarUrl = model.user.highQualityAvatarUrl
+        )
+    }
+}

--- a/dribbble/src/main/java/io/plaidapp/dribbble/domain/GetShareShotInfoUseCase.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/domain/GetShareShotInfoUseCase.kt
@@ -17,7 +17,7 @@
 package io.plaidapp.dribbble.domain
 
 import android.net.Uri
-import io.plaidapp.core.dribbble.data.api.model.Shot
+import io.plaidapp.dribbble.ui.shot.ShotUiModel
 import io.plaidapp.core.util.ImageUriProvider
 import javax.inject.Inject
 
@@ -26,13 +26,13 @@ import javax.inject.Inject
  */
 class GetShareShotInfoUseCase @Inject constructor(private val imageUriProvider: ImageUriProvider) {
 
-    suspend operator fun invoke(shot: Shot): ShareShotInfo {
-        val url = shot.images.best()
-        val imageSize = shot.images.bestSize()
+    suspend operator fun invoke(shotUiModel: ShotUiModel): ShareShotInfo {
+        val url = shotUiModel.imageUrl
+        val imageSize = shotUiModel.imageSize
         val uri = imageUriProvider(url, imageSize.width, imageSize.height)
-        val text = "“${shot.title}” by ${shot.user.name}\n${shot.url}"
+        val text = "“${shotUiModel.title}” by ${shotUiModel.userName}\n${shotUiModel.url}"
         val mime = getImageMimeType(url)
-        return ShareShotInfo(uri, shot.title, text, mime)
+        return ShareShotInfo(uri, shotUiModel.title, text, mime)
     }
 
     private fun getImageMimeType(fileName: String): String {

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotBindingAdapters.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.dribbble.ui.shot
+
+import android.graphics.drawable.AnimatedVectorDrawable
+import android.text.format.DateUtils
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.PluralsRes
+import androidx.databinding.BindingAdapter
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import io.plaidapp.core.util.HtmlUtils
+import io.plaidapp.core.util.glide.GlideApp
+import java.util.Date
+
+@BindingAdapter("relativeTime")
+fun bindRelativeTime(
+    textView: TextView,
+    date: Date?
+) {
+    date?.let {
+        textView.text = DateUtils.getRelativeTimeSpanString(
+            it.time,
+            System.currentTimeMillis(),
+            DateUtils.SECOND_IN_MILLIS
+        ).toString().toLowerCase()
+    }
+}
+
+@BindingAdapter("imageUrl", "placeholder", "circleCrop", "crossFade", requireAll = false)
+fun bindImage(
+    imageView: ImageView,
+    imageUrl: String?,
+    placeholder: Int? = null,
+    circleCrop: Boolean? = false,
+    crossFade: Boolean? = false
+) {
+    var request = GlideApp.with(imageView.context).load(imageUrl)
+    if (placeholder != null) {
+        request = request.placeholder(placeholder)
+    }
+    if (circleCrop == true) {
+        request = request.circleCrop()
+    }
+    if (crossFade == true) {
+        request = request.transition(DrawableTransitionOptions.withCrossFade())
+    }
+    request.into(imageView)
+}
+
+@BindingAdapter("htmlText")
+fun bindHtmlText(
+    textView: TextView,
+    htmlText: CharSequence?
+) {
+    if (htmlText == null) return
+    HtmlUtils.setTextWithNiceLinks(textView, htmlText)
+}
+
+@BindingAdapter("pluralResource", "pluralQuantity", "pluralValue", requireAll = true)
+fun bindNumberFormattedPlural(
+    textView: TextView,
+    @PluralsRes plural: Int,
+    pluralQuantity: Int,
+    pluralValue: String?
+) {
+    textView.text = textView.resources.getQuantityString(
+        plural,
+        pluralQuantity,
+        pluralValue ?: pluralQuantity.toString()
+    )
+}
+
+@BindingAdapter("animatedOnClick")
+fun bindAnimatedOnClick(
+    textView: TextView,
+    onClickAction: () -> Unit
+) = setAnimatedOnClick(textView, onClickAction)
+
+@BindingAdapter("animatedOnClick")
+fun bindAnimatedOnClick(
+    textView: TextView,
+    enabled: Boolean
+) = setAnimatedOnClick(textView, enabled = enabled)
+
+private fun setAnimatedOnClick(
+    textView: TextView,
+    onClickAction: (() -> Unit)? = null,
+    enabled: Boolean = true
+) {
+    textView.setOnClickListener {
+        // If the top compound drawable is an AVD then start it when clicked
+        (textView.compoundDrawables[1] as? AnimatedVectorDrawable)?.start()
+        if (enabled) {
+            onClickAction?.invoke()
+        }
+    }
+}

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotStyler.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotStyler.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.dribbble.ui.shot
+
+import android.content.Context
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.N
+import androidx.annotation.ColorInt
+import androidx.appcompat.content.res.AppCompatResources
+import io.plaidapp.core.util.ColorUtils
+import io.plaidapp.dribbble.R
+import javax.inject.Inject
+import io.plaidapp.core.R as coreR
+
+/**
+ * Decorator for a [ShotUiModel]
+ *  - locale is needed to format the views and likes count
+ *  - linkColors and highlightColor will define the colors used in the shot description
+ */
+class ShotStyler @Inject constructor(context: Context) {
+
+    @Suppress("DEPRECATION")
+    val locale = if (SDK_INT >= N) {
+        context.resources.configuration.locales[0]
+    } else {
+        context.resources.configuration.locale
+    }
+
+    val linkColors = AppCompatResources.getColorStateList(context, R.color.dribbble_links)!!
+
+    @ColorInt
+    val highlightColor = ColorUtils.getThemeColor(
+        context,
+        coreR.attr.colorPrimary,
+        coreR.color.primary
+    )
+}

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotUiModel.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotUiModel.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.dribbble.ui.shot
+
+import io.plaidapp.core.dribbble.data.api.model.Images
+import io.plaidapp.core.dribbble.data.api.model.Shot
+import java.util.Date
+
+/**
+ * Shot model for the UI
+ */
+data class ShotUiModel(
+    val id: Long,
+    val title: String,
+    val url: String,
+    val formattedDescription: CharSequence,
+    val imageUrl: String,
+    val imageSize: Images.ImageSize,
+    val likesCount: Int,
+    val formattedLikesCount: String,
+    val viewsCount: Int,
+    val formattedViewsCount: String,
+    val createdAt: Date?,
+    val userName: String,
+    val userAvatarUrl: String
+) {
+    val shouldHideDescription = formattedDescription.isEmpty()
+}
+
+/**
+ * A sync conversion which skips long running work in order to publish a result asap. For a more
+ * complete conversion see [io.plaidapp.dribbble.domain.CreateShotUiModelUseCase].
+ */
+fun Shot.toShotUiModel(): ShotUiModel {
+    return ShotUiModel(
+        id = id,
+        title = title,
+        url = htmlUrl,
+        formattedDescription = "",
+        imageUrl = images.best(),
+        imageSize = images.bestSize(),
+        likesCount = likesCount,
+        formattedLikesCount = likesCount.toString(),
+        viewsCount = viewsCount,
+        formattedViewsCount = viewsCount.toString(),
+        createdAt = createdAt,
+        userName = user.name.toLowerCase(),
+        userAvatarUrl = user.highQualityAvatarUrl
+    )
+}

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
@@ -25,9 +25,9 @@ import io.plaidapp.core.data.Result
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.util.event.Event
+import io.plaidapp.dribbble.domain.CreateShotUiModelUseCase
 import io.plaidapp.dribbble.domain.GetShareShotInfoUseCase
 import io.plaidapp.dribbble.domain.ShareShotInfo
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -37,22 +37,14 @@ import javax.inject.Inject
 class ShotViewModel @Inject constructor(
     shotId: Long,
     shotsRepository: ShotsRepository,
-    private val getShareShotInfoUseCase: GetShareShotInfoUseCase,
+    private val createShotUiModel: CreateShotUiModelUseCase,
+    private val getShareShotInfo: GetShareShotInfoUseCase,
     private val dispatcherProvider: CoroutinesDispatcherProvider
 ) : ViewModel() {
 
-    val shot: Shot
-    private var shareShotJob = Job()
-
-    init {
-        val result = shotsRepository.getShot(shotId)
-        if (result is Result.Success) {
-            shot = result.data
-        } else {
-            // TODO re-throw Error.exception once Loading state removed.
-            throw IllegalStateException("Could not retrieve shot $shotId")
-        }
-    }
+    private val _shotUiModel = MutableLiveData<ShotUiModel>()
+    val shotUiModel: LiveData<ShotUiModel>
+        get() = _shotUiModel
 
     private val _openLink = MutableLiveData<Event<String>>()
     val openLink: LiveData<Event<String>>
@@ -62,22 +54,44 @@ class ShotViewModel @Inject constructor(
     val shareShot: LiveData<Event<ShareShotInfo>>
         get() = _shareShot
 
+    init {
+        val result = shotsRepository.getShot(shotId)
+        if (result is Result.Success) {
+            _shotUiModel.value = result.data.toShotUiModel()
+            processUiModel(result.data)
+        } else {
+            // TODO re-throw Error.exception once Loading state removed.
+            throw IllegalStateException("Could not retrieve shot $shotId")
+        }
+    }
+
     fun shareShotRequested() {
-        shareShotJob.cancel()
-        shareShotJob = launchShare()
+        _shotUiModel.value?.let { model ->
+            viewModelScope.launch(dispatcherProvider.io) {
+                val shareInfo = getShareShotInfo(model)
+                _shareShot.postValue(Event(shareInfo))
+            }
+        }
     }
 
     fun viewShotRequested() {
-        _openLink.value = Event(shot.htmlUrl)
+        _shotUiModel.value?.let { model ->
+            _openLink.value = Event(model.url)
+        }
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        shareShotJob.cancel()
+    fun getAssistWebUrl(): String {
+        return shotUiModel.value?.url.orEmpty()
     }
 
-    private fun launchShare() = viewModelScope.launch(dispatcherProvider.computation) {
-        val shareInfo = getShareShotInfoUseCase(shot)
-        _shareShot.postValue(Event(shareInfo))
+    fun getShotId(): Long {
+        return shotUiModel.value?.id ?: -1L
+    }
+
+    private fun processUiModel(shot: Shot) {
+        viewModelScope.launch(dispatcherProvider.main) {
+            val uiModel = createShotUiModel(shot)
+            _shotUiModel.value = uiModel
+        }
     }
 }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModelFactory.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModelFactory.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
+import io.plaidapp.dribbble.domain.CreateShotUiModelUseCase
 import io.plaidapp.dribbble.domain.GetShareShotInfoUseCase
 import javax.inject.Inject
 
@@ -29,6 +30,7 @@ import javax.inject.Inject
 class ShotViewModelFactory @Inject constructor(
     private val shotId: Long,
     private val shotRepository: ShotsRepository,
+    private val createShotUiModel: CreateShotUiModelUseCase,
     private val getShareShotInfoUseCase: GetShareShotInfoUseCase,
     private val dispatcherProvider: CoroutinesDispatcherProvider
 ) : ViewModelProvider.Factory {
@@ -41,6 +43,7 @@ class ShotViewModelFactory @Inject constructor(
         return ShotViewModel(
             shotId,
             shotRepository,
+            createShotUiModel,
             getShareShotInfoUseCase,
             dispatcherProvider
         ) as T

--- a/dribbble/src/main/res/layout/activity_dribbble_shot.xml
+++ b/dribbble/src/main/res/layout/activity_dribbble_shot.xml
@@ -23,13 +23,25 @@
 
     <data>
 
+        <import type="android.graphics.drawable.Drawable" />
+
+        <import type="com.bumptech.glide.request.RequestListener" />
+
+        <import type="io.plaidapp.dribbble.R" />
+
+        <import type="io.plaidapp.R" alias="appR" />
+
         <variable
             name="viewModel"
             type="io.plaidapp.dribbble.ui.shot.ShotViewModel" />
 
         <variable
-            name="shotUiModel"
-            type="io.plaidapp.core.dribbble.data.api.model.Shot" />
+            name="uiModel"
+            type="io.plaidapp.dribbble.ui.shot.ShotUiModel" />
+
+        <variable
+            name="shotLoadListener"
+            type="RequestListener&lt;Drawable&gt;" />
 
     </data>
 
@@ -63,6 +75,11 @@
             android:transitionName="@string/transition_shot"
             android:background="@color/light_grey"
             android:onClick="@{() -> viewModel.viewShotRequested()}"
+            app:imageUrl="@{uiModel.imageUrl}"
+            app:imageLoadListener="@{shotLoadListener}"
+            app:crossFadeImage="@{true}"
+            app:overrideImageWidth="@{uiModel.imageSize.width}"
+            app:overrideImageHeight="@{uiModel.imageSize.height}"
             app:scrimColor="@color/scrim"
             app:scrimAlpha="0"
             app:maxScrimAlpha="0.4"
@@ -133,7 +150,7 @@
                     android:paddingStart="@dimen/padding_normal"
                     android:paddingTop="@dimen/padding_normal"
                     android:textAppearance="@style/TextAppearance.DribbbleShotTitle"
-                    android:text="@{shotUiModel.title}" />
+                    android:text="@{uiModel.title}" />
 
                 <io.plaidapp.core.ui.widget.BaselineGridTextView
                     android:id="@+id/shot_description"
@@ -148,6 +165,8 @@
                     android:textAppearance="@style/TextAppearance.DribbbleShotDescription"
                     android:textColorHighlight="@color/dribbble_link_highlight"
                     android:textColorLink="@color/dribbble_links"
+                    app:htmlText="@{uiModel.formattedDescription}"
+                    app:goneUnless="@{uiModel.shouldHideDescription}"
                     tools:text="Check out this sweet eye candy!" />
 
                 <Button
@@ -161,6 +180,10 @@
                     android:layout_marginTop="@dimen/spacing_large"
                     android:drawableTop="@drawable/avd_likes"
                     android:background="@null"
+                    app:animatedOnClick="@{true}"
+                    app:pluralResource="@{R.plurals.likes}"
+                    app:pluralQuantity="@{uiModel.likesCount}"
+                    app:pluralValue="@{uiModel.formattedLikesCount}"
                     tools:text="33 likes"
                     style="@style/Widget.Plaid.InlineActionButton" />
 
@@ -174,6 +197,10 @@
                     app:layout_constraintHorizontal_weight="1"
                     android:drawableTop="@drawable/avd_views"
                     android:background="@null"
+                    app:animatedOnClick="@{true}"
+                    app:pluralResource="@{R.plurals.views}"
+                    app:pluralQuantity="@{uiModel.viewsCount}"
+                    app:pluralValue="@{uiModel.formattedViewsCount}"
                     tools:text="33 views"
                     style="@style/Widget.Plaid.InlineActionButton" />
 
@@ -187,6 +214,7 @@
                     app:layout_constraintHorizontal_weight="1"
                     android:drawableTop="@drawable/avd_share"
                     android:text="@string/share"
+                    app:animatedOnClick="@{() -> viewModel.shareShotRequested()}"
                     style="@style/Widget.Plaid.InlineActionButton" />
 
                 <io.plaidapp.core.ui.widget.BaselineGridTextView
@@ -203,6 +231,7 @@
                     android:paddingTop="@dimen/spacing_normal"
                     android:textAppearance="@style/TextAppearance.CommentAuthor"
                     android:clickable="false"
+                    android:text="@{uiModel.userName}"
                     tools:text="—Nick B" />
 
                 <io.plaidapp.core.ui.widget.BaselineGridTextView
@@ -215,6 +244,7 @@
                     android:paddingStart="@dimen/padding_normal"
                     android:gravity="end"
                     android:textAppearance="@style/TextAppearance.CommentTimestamp"
+                    app:relativeTime="@{uiModel.createdAt}"
                     tools:text="3 hours ago" />
 
                 <io.plaidapp.core.ui.widget.CircularImageView
@@ -227,7 +257,11 @@
                     app:layout_constraintBottom_toBottomOf="@id/player_name"
                     android:padding="@dimen/avatar_padding"
                     android:src="@drawable/avatar_placeholder"
-                    android:foreground="@drawable/avatar_ripple" />
+                    android:foreground="@drawable/avatar_ripple"
+                    app:imageUrl="@{uiModel.userAvatarUrl}"
+                    app:imagePlaceholder="@{appR.drawable.avatar_placeholder}"
+                    app:circleCropImage="@{true}"
+                    app:crossFadeImage="@{true}"/>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/dribbble/src/test/java/io/plaidapp/dribbble/TestData.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/TestData.kt
@@ -19,6 +19,7 @@ package io.plaidapp.dribbble
 import io.plaidapp.core.dribbble.data.api.model.Images
 import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.dribbble.data.api.model.User
+import io.plaidapp.dribbble.ui.shot.ShotUiModel
 
 /**
  * Dribbble test data
@@ -34,7 +35,25 @@ val player = User(
 val testShot = Shot(
     id = 1L,
     title = "Foo",
-    description = "",
-    images = Images(),
-    user = player
+    description = "Shot Description",
+    images = Images(hidpi = "hidpi"),
+    user = player,
+    viewsCount = 1234,
+    likesCount = 5678
+)
+
+val testShotUiModel = ShotUiModel(
+    id = 1L,
+    title = "Foo",
+    url = "url",
+    formattedDescription = "Description",
+    imageUrl = "imageUrl",
+    imageSize = Images.ImageSize.NORMAL_IMAGE_SIZE,
+    viewsCount = 1234,
+    formattedViewsCount = "1,234",
+    likesCount = 5678,
+    formattedLikesCount = "5,678",
+    createdAt = null,
+    userName = "username",
+    userAvatarUrl = "avatarUrl"
 )

--- a/dribbble/src/test/java/io/plaidapp/dribbble/domain/CreateShotUiModelUseCaseTest.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/domain/CreateShotUiModelUseCaseTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.dribbble.domain
+
+import android.content.res.ColorStateList
+import android.text.SpannableStringBuilder
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.plaidapp.core.util.HtmlParser
+import io.plaidapp.dribbble.testShot
+import io.plaidapp.dribbble.ui.shot.ShotStyler
+import io.plaidapp.test.shared.provideFakeCoroutinesDispatcherProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * Test for [CreateShotUiModelUseCase] mocking all dependencies.
+ */
+class CreateShotUiModelUseCaseTest {
+
+    private val mockHtmlParser: HtmlParser = mock()
+    private val mockShotStyler: ShotStyler = mock {
+        on { linkColors } doReturn ColorStateList(arrayOf(intArrayOf(1)), intArrayOf(0xff00ff))
+        on { highlightColor } doReturn 0xff00ff
+        on { locale } doReturn Locale.US
+    }
+
+    private val createShotUiModel =
+        CreateShotUiModelUseCase(mockHtmlParser, mockShotStyler, provideFakeCoroutinesDispatcherProvider())
+
+    @Test
+    fun createModel_copiesFieldsFromShot() = runBlocking {
+        // Given that we have a shot with description
+        givenParsedHtml(testShot.description)
+
+        // When creating a shotUiModel out of it
+        val result = createShotUiModel(testShot)
+
+        // Then all non-modified fields are properly mapped
+        assertEquals(testShot.id, result.id)
+        assertEquals(testShot.title, result.title)
+        assertEquals(testShot.htmlUrl, result.url)
+        assertEquals(testShot.likesCount, result.likesCount)
+        assertEquals(testShot.viewsCount, result.viewsCount)
+        assertEquals(testShot.createdAt, result.createdAt)
+        assertEquals(testShot.images.best(), result.imageUrl)
+        assertEquals(testShot.images.bestSize(), result.imageSize)
+        assertEquals(testShot.user.name.toLowerCase(), result.userName)
+        assertEquals(testShot.user.highQualityAvatarUrl, result.userAvatarUrl)
+    }
+
+    @Test
+    fun createModel_formatsDescription() = runBlocking {
+        // Given that we have a shot with description
+        givenParsedHtml(testShot.description)
+
+        // When creating a shotUiModel out of it
+        val result = createShotUiModel(testShot)
+
+        // Then the original description has been formatted and it is visible
+        assertTrue(result.formattedDescription.isNotEmpty())
+        assertFalse(result.shouldHideDescription)
+    }
+
+    @Test
+    fun createModelWithoutDescription_hidesDescription() = runBlocking {
+        // Given that we have a shot without description
+        val noDescriptionShot = testShot.copy(
+            description = ""
+        )
+        givenParsedHtml(noDescriptionShot.description)
+
+        // When creating a shotUiModel out of it
+        val result = createShotUiModel(noDescriptionShot)
+
+        // Then the description is not visible and it is empty
+        assertTrue(result.formattedDescription.isEmpty())
+        assertTrue(result.shouldHideDescription)
+    }
+
+    @Test
+    fun createModel_formatsViewCount() = runBlocking {
+        // Given that we have a shot with description
+        givenParsedHtml(testShot.description)
+
+        // When creating a shotUiModel out of it
+        val result = createShotUiModel(testShot)
+
+        // Then the views count has been properly formatted
+        assertEquals("1,234", result.formattedViewsCount)
+    }
+
+    @Test
+    fun createModel_formatsLikesCount() = runBlocking {
+        // Given that we have a shot with description
+        givenParsedHtml(testShot.description)
+
+        // When creating a shotUiModel out of it
+        val result = createShotUiModel(testShot)
+
+        // Then the likes count has been properly formatted
+        assertEquals("5,678", result.formattedLikesCount)
+    }
+
+    /**
+     * Sets up the HtmlParser mock to return the length of the passed String object
+     */
+    private fun givenParsedHtml(parsedString: String) {
+        val mockSpannableStringBuilder: SpannableStringBuilder = mock {
+            on { length } doReturn parsedString.length
+        }
+        whenever(mockHtmlParser.parse(any(), any(), any())).thenReturn(mockSpannableStringBuilder)
+    }
+}

--- a/dribbble/src/test/java/io/plaidapp/dribbble/domain/GetShareShotInfoUseCaseTest.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/domain/GetShareShotInfoUseCaseTest.kt
@@ -20,10 +20,9 @@ import android.net.Uri
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
-import io.plaidapp.core.dribbble.data.api.model.Images
-import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.util.ImageUriProvider
-import io.plaidapp.dribbble.testShot
+import io.plaidapp.dribbble.testShotUiModel
+import io.plaidapp.dribbble.ui.shot.ShotUiModel
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -43,62 +42,55 @@ class GetShareShotInfoUseCaseTest {
     @Test
     fun getShareInfo_Png() = runBlocking {
         // Given a shot with a png image
-        val shot =
+        val shotUiModel =
             withUrl("https://cdn.dribbble.com/users/6295/screenshots/2344334/plaid_dribbble.png")
 
         // When invoking the use case
-        val shareInfo = getShareShotInfoUseCase(shot)
+        val result = getShareShotInfoUseCase(shotUiModel)
 
         // Then the expected share info is returned
-        assertNotNull(shareInfo)
-        assertEquals(shot.title, shareInfo.title)
-        assertFalse(shareInfo.shareText.isBlank())
-        assertTrue(shareInfo.shareText.contains(shot.title))
-        assertTrue(shareInfo.shareText.contains(shot.user.name))
-        assertTrue(shareInfo.shareText.contains(shot.htmlUrl))
-        assertTrue(shareInfo.mimeType.contains("png"))
+        result.assertWithShotUiModel(shotUiModel, mimeType = "png")
     }
 
     @Test
     fun getShareInfo_Gif() = runBlocking {
         // Given a shot with a gif image
-        val shot =
+        val shotUiModel =
             withUrl("https://cdn.dribbble.com/users/213811/screenshots/2916762/password_visibility_toggle.gif")
 
         // When invoking the use case
-        val shareInfo = getShareShotInfoUseCase(shot)
+        val result = getShareShotInfoUseCase(shotUiModel)
 
         // Then the expected share info is returned
-        assertNotNull(shareInfo)
-        assertEquals(shot.title, shareInfo.title)
-        assertFalse(shareInfo.shareText.isBlank())
-        assertTrue(shareInfo.shareText.contains(shot.title))
-        assertTrue(shareInfo.shareText.contains(shot.user.name))
-        assertTrue(shareInfo.shareText.contains(shot.htmlUrl))
-        assertTrue(shareInfo.mimeType.contains("gif"))
+        result.assertWithShotUiModel(shotUiModel, mimeType = "gif")
     }
 
     @Test
     fun getShareInfo_Jpeg() = runBlocking {
         // Given a shot with a jpg image
-        val shot = withUrl("https://cdn.dribbble.com/users/3557/screenshots/1550672/full2.jpg")
+        val shotUiModel = withUrl("https://cdn.dribbble.com/users/3557/screenshots/1550672/full2.jpg")
 
         // When invoking the use case
-        val shareInfo = getShareShotInfoUseCase(shot)
+        val result = getShareShotInfoUseCase(shotUiModel)
 
         // Then the expected share info is returned
-        assertNotNull(shareInfo)
-        assertEquals(shot.title, shareInfo.title)
-        assertFalse(shareInfo.shareText.isBlank())
-        assertTrue(shareInfo.shareText.contains(shot.title))
-        assertTrue(shareInfo.shareText.contains(shot.user.name))
-        assertTrue(shareInfo.shareText.contains(shot.htmlUrl))
-        assertTrue(shareInfo.mimeType.contains("jpeg"))
+        result.assertWithShotUiModel(shotUiModel, mimeType = "jpeg")
     }
 
-    private fun withUrl(url: String?): Shot {
-        val shot = testShot.copy(images = Images(hidpi = url))
+    private fun withUrl(url: String = ""): ShotUiModel {
+        val shotUiModel = testShotUiModel.copy(imageUrl = url)
         runBlocking { whenever(imageUriProvider(any(), any(), any())).thenReturn(uri) }
-        return shot
+        return shotUiModel
+    }
+
+    private fun ShareShotInfo.assertWithShotUiModel(shotUiModel: ShotUiModel, mimeType: String) {
+        assertNotNull(this)
+        assertEquals(shotUiModel.title, title)
+        assertFalse(shareText.isBlank())
+        assertNotNull(imageUri)
+        assertTrue(shareText.contains(shotUiModel.title))
+        assertTrue(shareText.contains(shotUiModel.userName))
+        assertTrue(shareText.contains(shotUiModel.url))
+        assertTrue(this.mimeType.contains(mimeType))
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 24 11:25:43 PST 2019
+#Wed Mar 06 13:11:31 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip


### PR DESCRIPTION
Refactor Dribble Shot feature to use UiModel

Changes:

- The activity gets massively simplified with no need to bind the shot.
- BindingAdapters taken from [Nick's commit](https://github.com/nickbutcher/plaid/commit/1bbd58c6fd5dc45fef961a1f01415e24de693142). Kudos to him!
- ViewModel exposes the shotUiModel via LiveData which is consumed by the view/xml with DataBinding.

Testing:

- The app works as before.
- Tested in an emulator.
- Added more unit tests and all of them pass