### PR TITLE
Temporarly disable DN Search Converter to fix issue #636.

### DIFF
--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -92,7 +92,7 @@ class DesignerNewsDataModule {
             .baseUrl(DesignerNewsService.ENDPOINT)
             .callFactory { client.get().newCall(it) }
             .addConverterFactory(DeEnvelopingConverter(gson))
-            .addConverterFactory(DesignerNewsSearchConverter.Factory())
+//            .addConverterFactory(DesignerNewsSearchConverter.Factory())
             .addConverterFactory(GsonConverterFactory.create(gson))
             .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .build()


### PR DESCRIPTION
This is a quick fix to be able to be able to login into Designer News, while a better fix is implemented.