### PR TITLE
Cleaning FeedAdapter - step 1

### DIFF
--- a/app/src/main/java/io/plaidapp/dagger/HomeModule.kt
+++ b/app/src/main/java/io/plaidapp/dagger/HomeModule.kt
@@ -22,7 +22,6 @@ import android.net.ConnectivityManager
 import androidx.core.content.getSystemService
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProviders
-import com.bumptech.glide.util.ViewPreloadSizeProvider
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -32,7 +31,6 @@ import io.plaidapp.core.dagger.OnDataLoadedModule
 import io.plaidapp.core.dagger.SourcesRepositoryModule
 import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
 import io.plaidapp.core.data.pocket.PocketUtils
-import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.ui.ConnectivityChecker
 import io.plaidapp.ui.HomeActivity
 import io.plaidapp.ui.HomeViewModel
@@ -66,10 +64,6 @@ abstract class HomeModule {
         @JvmStatic
         @Provides
         fun columns(activity: Activity): Int = activity.resources.getInteger(R.integer.num_columns)
-
-        @JvmStatic
-        @Provides
-        fun viewPreloadSizeProvider(): ViewPreloadSizeProvider<Shot> = ViewPreloadSizeProvider()
 
         @JvmStatic
         @Provides

--- a/app/src/main/java/io/plaidapp/ui/HomeActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/HomeActivity.java
@@ -142,13 +142,7 @@ public class HomeActivity extends FragmentActivity {
 
         boolean pocketInstalled = PocketUtils.isPocketInstalled(this);
 
-        adapter = new FeedAdapter(
-                this,
-                dataManager,
-                columns,
-                pocketInstalled,
-                new ViewPreloadSizeProvider<Shot>()
-        );
+        adapter = new FeedAdapter(this, dataManager, columns, pocketInstalled);
 
         if(connectivityChecker != null) {
             getLifecycle().addObserver(connectivityChecker);

--- a/app/src/main/java/io/plaidapp/ui/HomeActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/HomeActivity.java
@@ -66,6 +66,7 @@ import com.bumptech.glide.util.ViewPreloadSizeProvider;
 import io.plaidapp.R;
 import io.plaidapp.core.data.DataManager;
 import io.plaidapp.core.data.PlaidItem;
+import io.plaidapp.core.data.pocket.PocketUtils;
 import io.plaidapp.core.data.prefs.SourcesRepository;
 import io.plaidapp.core.designernews.data.poststory.PostStoryService;
 import io.plaidapp.core.designernews.data.stories.model.Story;
@@ -112,13 +113,12 @@ public class HomeActivity extends FragmentActivity {
     private int columns;
     private TextView noFiltersEmptyText;
     private FilterAdapter filtersAdapter;
+    private FeedAdapter adapter;
 
     // data
     @Inject
     DataManager dataManager;
 
-    @Inject
-    FeedAdapter adapter;
     @Inject
     SourcesRepository sourcesRepository;
     @Inject
@@ -139,6 +139,16 @@ public class HomeActivity extends FragmentActivity {
             adapter.setItems(items);
             checkEmptyState();
         });
+
+        boolean pocketInstalled = PocketUtils.isPocketInstalled(this);
+
+        adapter = new FeedAdapter(
+                this,
+                dataManager,
+                columns,
+                pocketInstalled,
+                new ViewPreloadSizeProvider<Shot>()
+        );
 
         if(connectivityChecker != null) {
             getLifecycle().addObserver(connectivityChecker);

--- a/core/src/main/java/io/plaidapp/core/ui/FeedAdapter.java
+++ b/core/src/main/java/io/plaidapp/core/ui/FeedAdapter.java
@@ -69,7 +69,6 @@ import io.plaidapp.core.util.glide.DribbbleTarget;
 import io.plaidapp.core.util.glide.GlideApp;
 import kotlin.Unit;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -104,7 +103,6 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
     private List<PlaidItem> items;
     private boolean showLoadingMore = false;
 
-    @Inject
     public FeedAdapter(Activity hostActivity,
                        @Nullable DataLoadingSubject dataLoading,
                        int columns,

--- a/core/src/main/java/io/plaidapp/core/ui/FeedAdapter.java
+++ b/core/src/main/java/io/plaidapp/core/ui/FeedAdapter.java
@@ -96,7 +96,7 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
     private final DataLoadingSubject dataLoading;
     private final int columns;
     private final ColorDrawable[] shotLoadingPlaceholders;
-    private final ViewPreloadSizeProvider<Shot> shotPreloadSizeProvider;
+    private final ViewPreloadSizeProvider<Shot> shotPreloadSizeProvider = new ViewPreloadSizeProvider<>();
 
     @ColorInt
     private final int initialGifBadgeColor;
@@ -106,7 +106,7 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
     public FeedAdapter(Activity hostActivity,
                        @Nullable DataLoadingSubject dataLoading,
                        int columns,
-                       boolean pocketInstalled, ViewPreloadSizeProvider<Shot> shotPreloadSizeProvider) {
+                       boolean pocketInstalled) {
         this.host = hostActivity;
         this.dataLoading = dataLoading;
         if (dataLoading != null) {
@@ -114,7 +114,6 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         }
         this.columns = columns;
         this.pocketIsInstalled = pocketInstalled;
-        this.shotPreloadSizeProvider = shotPreloadSizeProvider;
         layoutInflater = LayoutInflater.from(host);
         items = new ArrayList<>();
         setHasStableIds(true);

--- a/search/src/main/java/io/plaidapp/search/dagger/SearchModule.kt
+++ b/search/src/main/java/io/plaidapp/search/dagger/SearchModule.kt
@@ -20,7 +20,6 @@ import android.app.Activity
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProviders
-import com.bumptech.glide.util.ViewPreloadSizeProvider
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -30,7 +29,6 @@ import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
 import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
 import io.plaidapp.core.data.DataLoadingSubject
 import io.plaidapp.core.data.pocket.PocketUtils
-import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.search.domain.SearchDataManager
 import io.plaidapp.search.ui.SearchActivity
 import io.plaidapp.search.ui.SearchViewModel
@@ -63,10 +61,6 @@ abstract class SearchModule {
         @JvmStatic
         @Provides
         fun columns(activity: Activity): Int = activity.resources.getInteger(R.integer.num_columns)
-
-        @JvmStatic
-        @Provides
-        fun viewPreloadSizeProvider() = ViewPreloadSizeProvider<Shot>()
 
         @JvmStatic
         @Provides

--- a/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
+++ b/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
@@ -49,6 +49,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader
 import com.bumptech.glide.util.ViewPreloadSizeProvider
+import io.plaidapp.core.data.pocket.PocketUtils
 import io.plaidapp.core.dribbble.data.api.model.Shot
 import io.plaidapp.core.ui.FeedAdapter
 import io.plaidapp.core.ui.getPlaidItemsForDisplay
@@ -61,6 +62,7 @@ import io.plaidapp.core.util.TransitionUtils
 import io.plaidapp.core.util.event.EventObserver
 import io.plaidapp.search.R
 import io.plaidapp.search.dagger.Injector
+import io.plaidapp.search.domain.SearchDataManager
 import io.plaidapp.search.ui.transitions.CircularReveal
 import javax.inject.Inject
 
@@ -88,11 +90,13 @@ class SearchActivity : AppCompatActivity() {
     private val transitions = SparseArray<Transition>()
     private var focusQuery = true
 
+    private lateinit var feedAdapter: FeedAdapter
+
     @Inject
     lateinit var viewModel: SearchViewModel
 
     @Inject
-    lateinit var feedAdapter: FeedAdapter
+    lateinit var searchDataManager: SearchDataManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -101,6 +105,16 @@ class SearchActivity : AppCompatActivity() {
         setupSearchView()
 
         Injector.inject(this)
+
+        val pocketInstalled = PocketUtils.isPocketInstalled(this)
+
+        feedAdapter = FeedAdapter(
+            this,
+            searchDataManager,
+            columns,
+            pocketInstalled,
+            ViewPreloadSizeProvider<Shot>()
+        )
 
         viewModel.searchResults.observe(this, EventObserver { data ->
             if (data.isNotEmpty()) {

--- a/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
+++ b/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
@@ -108,13 +108,7 @@ class SearchActivity : AppCompatActivity() {
 
         val pocketInstalled = PocketUtils.isPocketInstalled(this)
 
-        feedAdapter = FeedAdapter(
-            this,
-            searchDataManager,
-            columns,
-            pocketInstalled,
-            ViewPreloadSizeProvider<Shot>()
-        )
+        feedAdapter = FeedAdapter(this, searchDataManager, columns, pocketInstalled)
 
         viewModel.searchResults.observe(this, EventObserver { data ->
             if (data.isNotEmpty()) {


### PR DESCRIPTION
* The Adapter doesn't need to be injected in the activities, the activity can just create it every time
* The `ViewPreloadSizeProvider` is specific to the Adapter so it doesn't need to be given as a constructor param. 