### PR TITLE
Cleaning FeedAdapter - step 2

### DIFF
--- a/app/src/main/java/io/plaidapp/ui/HomeActivity.java
+++ b/app/src/main/java/io/plaidapp/ui/HomeActivity.java
@@ -72,7 +72,7 @@ import io.plaidapp.core.designernews.data.poststory.PostStoryService;
 import io.plaidapp.core.designernews.data.stories.model.Story;
 import io.plaidapp.core.dribbble.data.api.model.Shot;
 import io.plaidapp.core.ui.ConnectivityChecker;
-import io.plaidapp.core.ui.FeedAdapter;
+import io.plaidapp.core.feed.FeedAdapter;
 import io.plaidapp.core.ui.HomeGridItemAnimator;
 import io.plaidapp.core.ui.PlaidItemsList;
 import io.plaidapp.core.ui.filter.FilterAdapter;
@@ -142,7 +142,7 @@ public class HomeActivity extends FragmentActivity {
 
         boolean pocketInstalled = PocketUtils.isPocketInstalled(this);
 
-        adapter = new FeedAdapter(this, dataManager, columns, pocketInstalled);
+        adapter = new FeedAdapter(this, columns, pocketInstalled);
 
         if(connectivityChecker != null) {
             getLifecycle().addObserver(connectivityChecker);
@@ -173,6 +173,14 @@ public class HomeActivity extends FragmentActivity {
                     handleDataSourceRemoved(source);
                     checkEmptyState();
                 });
+
+        viewModel.getFeedProgress().observe(this, feedProgressUiModel -> {
+            if(feedProgressUiModel.isLoading()){
+                adapter.dataStartedLoading();
+            } else {
+                adapter.dataFinishedLoading();
+            }
+        });
 
         drawer.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN

--- a/app/src/main/java/io/plaidapp/ui/HomeViewModel.kt
+++ b/app/src/main/java/io/plaidapp/ui/HomeViewModel.kt
@@ -21,10 +21,12 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import io.plaidapp.core.data.DataLoadingSubject
 import io.plaidapp.core.data.DataManager
 import io.plaidapp.core.data.Source
 import io.plaidapp.core.data.prefs.SourcesRepository
 import io.plaidapp.core.designernews.data.login.LoginRepository
+import io.plaidapp.core.feed.FeedProgressUiModel
 import io.plaidapp.core.ui.filter.FiltersChangedCallback
 import io.plaidapp.core.ui.filter.SourceUiModel
 import io.plaidapp.core.ui.filter.SourcesHighlightUiModel
@@ -55,6 +57,10 @@ class HomeViewModel(
     val sources: LiveData<SourcesUiModel>
         get() = _sources
 
+    private val _feedProgress = MutableLiveData<FeedProgressUiModel>()
+    val feedProgress: LiveData<FeedProgressUiModel>
+        get() = _feedProgress
+
     // listener for notifying adapter when data sources are deactivated
     private val filtersChangedCallbacks = object : FiltersChangedCallback() {
         override fun onFiltersChanged(changedFilter: Source) {
@@ -72,8 +78,19 @@ class HomeViewModel(
         }
     }
 
+    private val dataLoadingCallbacks = object : DataLoadingSubject.DataLoadingCallbacks {
+        override fun dataStartedLoading() {
+            _feedProgress.value = FeedProgressUiModel(true)
+        }
+
+        override fun dataFinishedLoading() {
+            _feedProgress.value = FeedProgressUiModel(false)
+        }
+    }
+
     init {
         sourcesRepository.registerFilterChangedCallback(filtersChangedCallbacks)
+        dataManager.registerCallback(dataLoadingCallbacks)
         getSources()
     }
 

--- a/app/src/test/java/io/plaidapp/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/io/plaidapp/ui/HomeViewModelTest.kt
@@ -41,7 +41,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
-import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 
 /**
@@ -154,7 +153,7 @@ class HomeViewModelTest {
     fun filtersUpdated_newSources() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
 
@@ -178,7 +177,7 @@ class HomeViewModelTest {
         // Given a view model
         val sources = mutableListOf<Source>(designerNewsSource)
         val homeViewModel = createViewModel(sources)
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
 
@@ -202,7 +201,7 @@ class HomeViewModelTest {
     fun sourceClicked_changesSourceActiveState() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
         // Given that filters were updated
@@ -222,7 +221,7 @@ class HomeViewModelTest {
     fun sourceRemoved_swipeDismissable() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
         // Given that filters were updated
@@ -242,7 +241,7 @@ class HomeViewModelTest {
     fun sourceRemoved_notSwipeDismissable() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
         // Given that filters were updated
@@ -262,7 +261,7 @@ class HomeViewModelTest {
     fun filtersRemoved() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
 
@@ -278,7 +277,7 @@ class HomeViewModelTest {
     fun filtersChanged_activeSource() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
 
@@ -295,7 +294,7 @@ class HomeViewModelTest {
     fun filtersChanged_inactiveSource() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(sourcesRepository).registerFilterChangedCallback(
+        verify(sourcesRepository).registerFilterChangedCallback(
             capture(filtersChangedCallback)
         )
 
@@ -312,7 +311,7 @@ class HomeViewModelTest {
     fun dataLoading() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(dataManager).registerCallback(capture(dataLoadingCallback))
+        verify(dataManager).registerCallback(capture(dataLoadingCallback))
 
         // When data started loading
         dataLoadingCallback.value.dataStartedLoading()
@@ -326,7 +325,7 @@ class HomeViewModelTest {
     fun dataFinishedLoading() {
         // Given a view model
         val homeViewModel = createViewModel()
-        Mockito.verify(dataManager).registerCallback(capture(dataLoadingCallback))
+        verify(dataManager).registerCallback(capture(dataLoadingCallback))
 
         // When data finished loading
         dataLoadingCallback.value.dataFinishedLoading()

--- a/core/src/main/java/io/plaidapp/core/feed/FeedAdapter.java
+++ b/core/src/main/java/io/plaidapp/core/feed/FeedAdapter.java
@@ -15,7 +15,7 @@
  *
  */
 
-package io.plaidapp.core.ui;
+package io.plaidapp.core.feed;
 
 import android.app.Activity;
 import android.app.ActivityOptions;
@@ -50,7 +50,6 @@ import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.bumptech.glide.util.ViewPreloadSizeProvider;
 import io.plaidapp.core.R;
-import io.plaidapp.core.data.DataLoadingSubject;
 import io.plaidapp.core.data.PlaidItem;
 import io.plaidapp.core.data.pocket.PocketUtils;
 import io.plaidapp.core.designernews.data.stories.model.Story;
@@ -59,6 +58,8 @@ import io.plaidapp.core.dribbble.data.api.model.Images;
 import io.plaidapp.core.dribbble.data.api.model.Shot;
 import io.plaidapp.core.producthunt.data.api.model.Post;
 import io.plaidapp.core.producthunt.ui.ProductHuntPostHolder;
+import io.plaidapp.core.ui.DribbbleShotHolder;
+import io.plaidapp.core.ui.HomeGridItemAnimator;
 import io.plaidapp.core.ui.transitions.ReflowText;
 import io.plaidapp.core.util.Activities;
 import io.plaidapp.core.util.ActivityHelper;
@@ -78,8 +79,7 @@ import java.util.Map;
  * Adapter for displaying a grid of {@link PlaidItem}s.
  */
 public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
-        implements DataLoadingSubject.DataLoadingCallbacks,
-        ListPreloader.PreloadModelProvider<Shot> {
+        implements ListPreloader.PreloadModelProvider<Shot> {
 
     public static final int REQUEST_CODE_VIEW_SHOT = 5407;
 
@@ -92,8 +92,6 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
     private final Activity host;
     private final LayoutInflater layoutInflater;
     private final boolean pocketIsInstalled;
-    @Nullable
-    private final DataLoadingSubject dataLoading;
     private final int columns;
     private final ColorDrawable[] shotLoadingPlaceholders;
     private final ViewPreloadSizeProvider<Shot> shotPreloadSizeProvider = new ViewPreloadSizeProvider<>();
@@ -104,14 +102,9 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
     private boolean showLoadingMore = false;
 
     public FeedAdapter(Activity hostActivity,
-                       @Nullable DataLoadingSubject dataLoading,
                        int columns,
                        boolean pocketInstalled) {
         this.host = hostActivity;
-        this.dataLoading = dataLoading;
-        if (dataLoading != null) {
-            dataLoading.registerCallback(this);
-        }
         this.columns = columns;
         this.pocketIsInstalled = pocketInstalled;
         layoutInflater = LayoutInflater.from(host);
@@ -326,10 +319,7 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
     private void bindLoadingViewHolder(LoadingMoreHolder holder, int position) {
         // only show the infinite load progress spinner if there are already items in the
         // grid i.e. it's not the first item & data is being loaded
-        holder.setVisibility((position > 0
-                && dataLoading != null
-                && dataLoading.isDataLoading())
-                ? View.VISIBLE : View.INVISIBLE);
+        holder.setVisibility((position > 0 && showLoadingMore) ? View.VISIBLE : View.INVISIBLE);
     }
 
     @Override
@@ -358,11 +348,6 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
             return columns;
         }
         return getItem(position).getColspan();
-    }
-
-    public void clear() {
-        items.clear();
-        notifyDataSetChanged();
     }
 
     /**
@@ -428,14 +413,12 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         return showLoadingMore ? getItemCount() - 1 : RecyclerView.NO_POSITION;
     }
 
-    @Override
     public void dataStartedLoading() {
         if (showLoadingMore) return;
         showLoadingMore = true;
         notifyItemInserted(getLoadingMoreItemPosition());
     }
 
-    @Override
     public void dataFinishedLoading() {
         if (!showLoadingMore) return;
         final int loadingPos = getLoadingMoreItemPosition();

--- a/core/src/main/java/io/plaidapp/core/feed/FeedUiModel.kt
+++ b/core/src/main/java/io/plaidapp/core/feed/FeedUiModel.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.core.feed
+
+import io.plaidapp.core.data.PlaidItem
+
+/**
+ * UI model for feed data
+ */
+data class FeedUiModel(
+    val items: List<PlaidItem>
+)
+
+data class FeedProgressUiModel(
+    val isLoading: Boolean
+)

--- a/search/src/test/java/io/plaidapp/search/ui/SearchViewModelTest.kt
+++ b/search/src/test/java/io/plaidapp/search/ui/SearchViewModelTest.kt
@@ -16,18 +16,42 @@
 
 package io.plaidapp.search.ui
 
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.nhaarman.mockitokotlin2.capture
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import io.plaidapp.core.data.DataLoadingSubject
+import io.plaidapp.core.feed.FeedProgressUiModel
 import io.plaidapp.search.domain.SearchDataManager
+import io.plaidapp.test.shared.LiveDataTestUtil
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
 
 /**
  * Tests for [SearchViewModel] that mocks the dependencies
  */
 class SearchViewModelTest {
 
+    // Executes tasks in the Architecture Components in the same thread
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
     private val dataManager: SearchDataManager = mock()
     private val viewModel = SearchViewModel(dataManager)
+
+    @Captor
+    private lateinit var dataLoadingCallback: ArgumentCaptor<DataLoadingSubject.DataLoadingCallbacks>
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+    }
 
     @Test
     fun searchFor_searchesInDataManager() {
@@ -57,5 +81,31 @@ class SearchViewModelTest {
 
         // Then clear results is called in data manager
         verify(dataManager).clear()
+    }
+
+    @Test
+    fun dataLoading() {
+        // Given a view model
+        Mockito.verify(dataManager).registerCallback(capture(dataLoadingCallback))
+
+        // When data started loading
+        dataLoadingCallback.value.dataStartedLoading()
+
+        // Then the feedProgress emits true
+        val progress = LiveDataTestUtil.getValue(viewModel.searchProgress)
+        Assert.assertEquals(FeedProgressUiModel(true), progress)
+    }
+
+    @Test
+    fun dataFinishedLoading() {
+        // Given a view model
+        Mockito.verify(dataManager).registerCallback(capture(dataLoadingCallback))
+
+        // When data finished loading
+        dataLoadingCallback.value.dataFinishedLoading()
+
+        // Then the feedProgress emits false
+        val progress = LiveDataTestUtil.getValue(viewModel.searchProgress)
+        Assert.assertEquals(FeedProgressUiModel(false), progress)
     }
 }

--- a/search/src/test/java/io/plaidapp/search/ui/SearchViewModelTest.kt
+++ b/search/src/test/java/io/plaidapp/search/ui/SearchViewModelTest.kt
@@ -30,7 +30,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
-import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 
 /**
@@ -86,7 +85,7 @@ class SearchViewModelTest {
     @Test
     fun dataLoading() {
         // Given a view model
-        Mockito.verify(dataManager).registerCallback(capture(dataLoadingCallback))
+        verify(dataManager).registerCallback(capture(dataLoadingCallback))
 
         // When data started loading
         dataLoadingCallback.value.dataStartedLoading()
@@ -99,7 +98,7 @@ class SearchViewModelTest {
     @Test
     fun dataFinishedLoading() {
         // Given a view model
-        Mockito.verify(dataManager).registerCallback(capture(dataLoadingCallback))
+        verify(dataManager).registerCallback(capture(dataLoadingCallback))
 
         // When data finished loading
         dataLoadingCallback.value.dataFinishedLoading()


### PR DESCRIPTION
Removing DataLoadingSubject from FeedAdapter and moving the logic to the Home and Search ViewModels