### PR TITLE
Update AGP to 3.4.0-rc01

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-beta04'
+        classpath 'com.android.tools.build:gradle:3.4.0-rc01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"


### PR DESCRIPTION
Updates to the latest RC. It seems to resolve an issue in AAPT which causes #642 to fail.

There's `3.5.0-alpha06` but it'd also require a Gradle update (happy to do this, if preferred).