### PR TITLE
Refactor Dagger components to use CoreComponent

### DIFF
--- a/app/src/main/java/io/plaidapp/dagger/HomeComponent.kt
+++ b/app/src/main/java/io/plaidapp/dagger/HomeComponent.kt
@@ -27,7 +27,10 @@ import io.plaidapp.ui.HomeActivity
 /**
  * Dagger component for the [HomeActivity].
  */
-@Component(modules = [HomeModule::class], dependencies = [CoreComponent::class])
+@Component(
+        modules = [HomeModule::class, SharedPreferencesModule::class],
+        dependencies = [CoreComponent::class]
+)
 interface HomeComponent : BaseActivityComponent<HomeActivity> {
 
     @Component.Builder

--- a/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
+++ b/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
@@ -29,8 +29,7 @@ class PlaidApplication : Application() {
 
     private val coreComponent: CoreComponent by lazy {
         DaggerCoreComponent
-            .builder()
-            .build()
+            .create()
     }
 
     companion object {

--- a/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
+++ b/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
@@ -21,7 +21,6 @@ import android.app.Application
 import android.content.Context
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.DaggerCoreComponent
-import io.plaidapp.core.dagger.MarkdownModule
 
 /**
  * Io and Behold
@@ -31,7 +30,6 @@ class PlaidApplication : Application() {
     private val coreComponent: CoreComponent by lazy {
         DaggerCoreComponent
             .builder()
-            .markdownModule(MarkdownModule(resources.displayMetrics))
             .build()
     }
 

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
@@ -16,30 +16,27 @@
 
 package io.plaidapp.core.dagger
 
+import com.google.gson.Gson
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import dagger.Component
-import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
-import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
+import okhttp3.OkHttpClient
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Named
 
 /**
  * Component providing application wide singletons.
  * To call this make use of PlaidApplication.coreComponent or the
  * Activity.coreComponent extension function.
  */
-@Component(
-    modules = [
-        CoreDataModule::class,
-        DesignerNewsDataModule::class,
-        DribbbleDataModule::class,
-        MarkdownModule::class,
-        ProductHuntModule::class,
-        SharedPreferencesModule::class
-    ]
-)
+@Component(modules = [CoreDataModule::class])
 interface CoreComponent {
 
     @Component.Builder interface Builder {
         fun build(): CoreComponent
-        fun markdownModule(module: MarkdownModule): Builder
-        fun sharedPreferencesModuleModule(module: SharedPreferencesModule): Builder
     }
+
+    @Named("coreOkHttpClient") fun provideOkHttpClient(): OkHttpClient
+    fun provideGson(): Gson
+    fun provideGsonConverterFactory(): GsonConverterFactory
+    fun provideCallAdapterFactory(): CoroutineCallAdapterFactory
 }

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
@@ -21,7 +21,6 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Component
 import okhttp3.OkHttpClient
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Named
 
 /**
  * Component providing application wide singletons.
@@ -35,7 +34,7 @@ interface CoreComponent {
         fun build(): CoreComponent
     }
 
-    @Named("coreOkHttpClient") fun provideOkHttpClient(): OkHttpClient
+    fun provideOkHttpClient(): OkHttpClient
     fun provideGson(): Gson
     fun provideGsonConverterFactory(): GsonConverterFactory
     fun provideCallAdapterFactory(): CoroutineCallAdapterFactory

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
@@ -24,6 +24,7 @@ import io.plaidapp.core.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Named
 
 /**
  * Dagger module to provide core data functionality.
@@ -32,6 +33,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class CoreDataModule {
 
     @Provides
+    @Named("coreOkHttpClient")
     fun provideOkHttpClient(interceptor: HttpLoggingInterceptor): OkHttpClient =
         OkHttpClient.Builder().addInterceptor(interceptor).build()
 

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
@@ -24,7 +24,6 @@ import io.plaidapp.core.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Named
 
 /**
  * Dagger module to provide core data functionality.
@@ -33,7 +32,6 @@ import javax.inject.Named
 class CoreDataModule {
 
     @Provides
-    @Named("coreOkHttpClient")
     fun provideOkHttpClient(interceptor: HttpLoggingInterceptor): OkHttpClient =
         OkHttpClient.Builder().addInterceptor(interceptor).build()
 

--- a/core/src/main/java/io/plaidapp/core/dagger/LocalApis.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/LocalApis.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.plaidapp.core.dagger
+
+import javax.inject.Qualifier
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class DesignerNewsApi
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class ProductHuntApi

--- a/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
@@ -30,6 +30,7 @@ import io.plaidapp.core.producthunt.data.api.ProductHuntService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Named
 import javax.inject.Qualifier
 import kotlin.annotation.AnnotationRetention.BINARY
 
@@ -40,7 +41,7 @@ private annotation class LocalApi
 /**
  * Dagger module to provide injections for Product Hunt.
  */
-@Module(includes = [CoreDataModule::class])
+@Module
 class ProductHuntModule {
 
     @Provides
@@ -51,7 +52,9 @@ class ProductHuntModule {
 
     @LocalApi
     @Provides
-    fun providePrivateOkHttpClient(upstreamClient: OkHttpClient): OkHttpClient {
+    fun providePrivateOkHttpClient(
+        @Named("coreOkHttpClient") upstreamClient: OkHttpClient
+    ): OkHttpClient {
         return upstreamClient.newBuilder()
             .addInterceptor(AuthInterceptor(BuildConfig.PRODUCT_HUNT_DEVELOPER_TOKEN))
             .build()

--- a/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
@@ -30,13 +30,6 @@ import io.plaidapp.core.producthunt.data.api.ProductHuntService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Named
-import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.BINARY
-
-@Retention(BINARY)
-@Qualifier
-private annotation class LocalApi
 
 /**
  * Dagger module to provide injections for Product Hunt.
@@ -50,10 +43,10 @@ class ProductHuntModule {
         dispatcherProvider: CoroutinesDispatcherProvider
     ) = ProductHuntRepository.getInstance(remoteDataSource, dispatcherProvider)
 
-    @LocalApi
+    @ProductHuntApi
     @Provides
     fun providePrivateOkHttpClient(
-        @Named("coreOkHttpClient") upstreamClient: OkHttpClient
+        upstreamClient: OkHttpClient
     ): OkHttpClient {
         return upstreamClient.newBuilder()
             .addInterceptor(AuthInterceptor(BuildConfig.PRODUCT_HUNT_DEVELOPER_TOKEN))
@@ -62,7 +55,7 @@ class ProductHuntModule {
 
     @Provides
     fun provideProductHuntService(
-        @LocalApi okhttpClient: Lazy<OkHttpClient>,
+        @ProductHuntApi okhttpClient: Lazy<OkHttpClient>,
         converterFactory: GsonConverterFactory,
         deEnvelopingConverter: DeEnvelopingConverter,
         callAdapterFactory: CoroutineCallAdapterFactory

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -24,6 +24,7 @@ import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.BuildConfig
+import io.plaidapp.core.dagger.DesignerNewsApi
 import io.plaidapp.core.data.api.DeEnvelopingConverter
 import io.plaidapp.core.designernews.data.api.ClientAuthInterceptor
 import io.plaidapp.core.designernews.data.api.DesignerNewsSearchConverter
@@ -39,7 +40,6 @@ import io.plaidapp.core.designernews.data.stories.StoriesRepository
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Named
 
 /**
  * Dagger module to provide data functionality for DesignerNews.
@@ -61,9 +61,9 @@ class DesignerNewsDataModule {
         AuthTokenLocalDataSource.getInstance(sharedPreferences)
 
     @Provides
-    @Named("designerNewsOkHttpClient")
+    @DesignerNewsApi
     fun providePrivateOkHttpClient(
-        @Named("coreOkHttpClient") upstream: OkHttpClient,
+        upstream: OkHttpClient,
         tokenHolder: AuthTokenLocalDataSource
     ): OkHttpClient {
         return upstream.newBuilder()
@@ -73,7 +73,7 @@ class DesignerNewsDataModule {
 
     @Provides
     fun provideDesignerNewsService(
-        @Named("designerNewsOkHttpClient") client: Lazy<OkHttpClient>,
+        @DesignerNewsApi client: Lazy<OkHttpClient>,
         gson: Gson
     ): DesignerNewsService {
         return Retrofit.Builder()

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -24,8 +24,6 @@ import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.BuildConfig
-import io.plaidapp.core.dagger.CoreDataModule
-import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.data.api.DeEnvelopingConverter
 import io.plaidapp.core.designernews.data.api.ClientAuthInterceptor
 import io.plaidapp.core.designernews.data.api.DesignerNewsSearchConverter
@@ -41,22 +39,12 @@ import io.plaidapp.core.designernews.data.stories.StoriesRepository
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.BINARY
-
-@Retention(BINARY)
-@Qualifier
-private annotation class LocalApi
+import javax.inject.Named
 
 /**
  * Dagger module to provide data functionality for DesignerNews.
  */
-@Module(
-    includes = [
-        SharedPreferencesModule::class,
-        CoreDataModule::class
-    ]
-)
+@Module
 class DesignerNewsDataModule {
 
     @Provides
@@ -72,10 +60,10 @@ class DesignerNewsDataModule {
     ): AuthTokenLocalDataSource =
         AuthTokenLocalDataSource.getInstance(sharedPreferences)
 
-    @LocalApi
     @Provides
+    @Named("designerNewsOkHttpClient")
     fun providePrivateOkHttpClient(
-        upstream: OkHttpClient,
+        @Named("coreOkHttpClient") upstream: OkHttpClient,
         tokenHolder: AuthTokenLocalDataSource
     ): OkHttpClient {
         return upstream.newBuilder()
@@ -85,7 +73,7 @@ class DesignerNewsDataModule {
 
     @Provides
     fun provideDesignerNewsService(
-        @LocalApi client: Lazy<OkHttpClient>,
+        @Named("designerNewsOkHttpClient") client: Lazy<OkHttpClient>,
         gson: Gson
     ): DesignerNewsService {
         return Retrofit.Builder()

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/Injector.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/Injector.kt
@@ -18,6 +18,8 @@
 
 package io.plaidapp.core.dagger.designernews
 
+import io.plaidapp.core.dagger.CoreComponent
+import io.plaidapp.core.dagger.DaggerCoreComponent
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.designernews.data.login.LoginLocalDataSource
 import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
@@ -26,9 +28,16 @@ import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
  * Injector for [UpvoteStoryService].
  */
 
+private val coreComponent: CoreComponent by lazy {
+    DaggerCoreComponent
+        .builder()
+        .build()
+}
+
 fun inject(service: UpvoteStoryService) {
 
     DaggerUpvoteStoryServiceComponent.builder()
+            .coreComponent(coreComponent)
             .sharedPreferencesModule(
                     SharedPreferencesModule(service, LoginLocalDataSource.DESIGNER_NEWS_PREF)
             )

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/UpvoteStoryServiceComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/UpvoteStoryServiceComponent.kt
@@ -18,7 +18,7 @@ package io.plaidapp.core.dagger.designernews
 
 import dagger.Component
 import io.plaidapp.core.dagger.BaseServiceComponent
-import io.plaidapp.core.dagger.CoreDataModule
+import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
 
@@ -28,16 +28,17 @@ import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
 @Component(
     modules = [
         UpvoteStoryServiceModule::class,
-        CoreDataModule::class,
-        DesignerNewsDataModule::class
-    ]
+        DesignerNewsDataModule::class,
+        SharedPreferencesModule::class
+    ],
+    dependencies = [CoreComponent::class]
 )
 interface UpvoteStoryServiceComponent : BaseServiceComponent<UpvoteStoryService> {
 
     @Component.Builder
     interface Builder {
-
         fun build(): UpvoteStoryServiceComponent
+        fun coreComponent(component: CoreComponent): Builder
         fun sharedPreferencesModule(module: SharedPreferencesModule): Builder
         fun upvoteServiceModule(module: UpvoteStoryServiceModule): Builder
     }

--- a/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
@@ -20,7 +20,6 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
-import io.plaidapp.core.dagger.CoreDataModule
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.search.DribbbleSearchConverter
@@ -28,11 +27,12 @@ import io.plaidapp.core.dribbble.data.search.DribbbleSearchService
 import io.plaidapp.core.dribbble.data.search.SearchRemoteDataSource
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import javax.inject.Named
 
 /**
  * Dagger module providing classes required to dribbble with data.
  */
-@Module(includes = [CoreDataModule::class])
+@Module
 class DribbbleDataModule {
 
     @Provides
@@ -47,7 +47,7 @@ class DribbbleDataModule {
 
     @Provides
     fun provideDribbbleSearchService(
-        client: Lazy<OkHttpClient>,
+        @Named("coreOkHttpClient") client: Lazy<OkHttpClient>,
         converterFactory: DribbbleSearchConverter.Factory,
         callAdapterFactory: CoroutineCallAdapterFactory
     ): DribbbleSearchService =

--- a/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
@@ -27,7 +27,6 @@ import io.plaidapp.core.dribbble.data.search.DribbbleSearchService
 import io.plaidapp.core.dribbble.data.search.SearchRemoteDataSource
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
-import javax.inject.Named
 
 /**
  * Dagger module providing classes required to dribbble with data.
@@ -47,7 +46,7 @@ class DribbbleDataModule {
 
     @Provides
     fun provideDribbbleSearchService(
-        @Named("coreOkHttpClient") client: Lazy<OkHttpClient>,
+        client: Lazy<OkHttpClient>,
         converterFactory: DribbbleSearchConverter.Factory,
         callAdapterFactory: CoroutineCallAdapterFactory
     ): DribbbleSearchService =

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
@@ -21,48 +21,22 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
-import io.plaidapp.core.BuildConfig
-import io.plaidapp.core.dagger.CoreDataModule
-import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.data.api.DeEnvelopingConverter
-import io.plaidapp.core.designernews.data.login.AuthTokenLocalDataSource
-import io.plaidapp.designernews.data.api.ClientAuthInterceptor
 import io.plaidapp.designernews.data.api.DesignerNewsService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Qualifier
-import kotlin.annotation.AnnotationRetention.BINARY
-
-@Retention(BINARY)
-@Qualifier
-private annotation class LocalApi
+import javax.inject.Named
 
 /**
  * Dagger module to provide data functionality for DesignerNews.
  */
-@Module(
-    includes = [
-        SharedPreferencesModule::class,
-        CoreDataModule::class
-    ]
-)
+@Module
 class DataModule {
-
-    @LocalApi
-    @Provides
-    fun providePrivateOkHttpClient(
-        upstream: OkHttpClient,
-        tokenHolder: AuthTokenLocalDataSource
-    ): OkHttpClient {
-        return upstream.newBuilder()
-            .addInterceptor(ClientAuthInterceptor(tokenHolder, BuildConfig.DESIGNER_NEWS_CLIENT_ID))
-            .build()
-    }
 
     @Provides
     fun provideDesignerNewsService(
-        @LocalApi client: Lazy<OkHttpClient>,
+        @Named("designerNewsOkHttpClient") client: Lazy<OkHttpClient>,
         gson: Gson
     ): DesignerNewsService {
         return Retrofit.Builder()

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
@@ -26,7 +26,6 @@ import io.plaidapp.designernews.data.api.DesignerNewsService
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import javax.inject.Named
 
 /**
  * Dagger module to provide data functionality for DesignerNews.
@@ -36,7 +35,7 @@ class DataModule {
 
     @Provides
     fun provideDesignerNewsService(
-        @Named("designerNewsOkHttpClient") client: Lazy<OkHttpClient>,
+        client: Lazy<OkHttpClient>,
         gson: Gson
     ): DesignerNewsService {
         return Retrofit.Builder()

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/Injector.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/Injector.kt
@@ -57,6 +57,7 @@ fun inject(storyId: Long, activity: StoryActivity) {
 fun inject(activity: LoginActivity) {
 
     DaggerLoginComponent.builder()
+        .coreComponent(activity.coreComponent())
         .sharedPreferencesModule(DesignerNewsPreferencesModule(activity))
         .build()
         .inject(activity)

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/LoginComponent.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/LoginComponent.kt
@@ -18,7 +18,7 @@ package io.plaidapp.designernews.dagger
 
 import dagger.Component
 import io.plaidapp.core.dagger.BaseActivityComponent
-import io.plaidapp.core.dagger.CoreDataModule
+import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
 import io.plaidapp.designernews.ui.login.LoginActivity
@@ -28,14 +28,15 @@ import io.plaidapp.designernews.ui.login.LoginActivity
  */
 @Component(
     modules = [
-        CoreDataModule::class,
         DesignerNewsDataModule::class,
         SharedPreferencesModule::class
-    ]
+    ],
+    dependencies = [CoreComponent::class]
 )
 interface LoginComponent : BaseActivityComponent<LoginActivity> {
 
     interface Builder {
+        fun coreComponent(component: CoreComponent): Builder
         fun sharedPreferencesModule(module: SharedPreferencesModule): Builder
         fun build(): LoginComponent
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryComponent.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryComponent.kt
@@ -21,12 +21,21 @@ import io.plaidapp.core.dagger.BaseActivityComponent
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.MarkdownModule
 import io.plaidapp.core.dagger.SharedPreferencesModule
+import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
 import io.plaidapp.designernews.ui.story.StoryActivity
 
 /**
  * Dagger component for [StoryActivity].
  */
-@Component(modules = [StoryModule::class], dependencies = [CoreComponent::class])
+@Component(
+    modules = [
+        SharedPreferencesModule::class,
+        MarkdownModule::class,
+        DesignerNewsDataModule::class,
+        DataModule::class,
+        StoryModule::class],
+    dependencies = [CoreComponent::class]
+)
 interface StoryComponent : BaseActivityComponent<StoryActivity> {
 
     @Component.Builder

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
@@ -19,10 +19,6 @@ package io.plaidapp.designernews.dagger
 import androidx.lifecycle.ViewModelProviders
 import dagger.Module
 import dagger.Provides
-import io.plaidapp.core.dagger.CoreDataModule
-import io.plaidapp.core.dagger.MarkdownModule
-import io.plaidapp.core.dagger.SharedPreferencesModule
-import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
@@ -46,13 +42,7 @@ import io.plaidapp.designernews.ui.story.StoryViewModelFactory
 /**
  * Dagger module for [StoryActivity].
  */
-@Module(
-    includes = [CoreDataModule::class,
-        DesignerNewsDataModule::class,
-        DataModule::class,
-        MarkdownModule::class,
-        SharedPreferencesModule::class]
-)
+@Module
 class StoryModule(private val storyId: Long, private val activity: StoryActivity) {
 
     @Provides

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleComponent.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleComponent.kt
@@ -19,7 +19,6 @@ package io.plaidapp.dribbble.dagger
 import dagger.Component
 import io.plaidapp.core.dagger.BaseActivityComponent
 import io.plaidapp.core.dagger.CoreComponent
-import io.plaidapp.core.dagger.CoreDataModule
 import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
 import io.plaidapp.dribbble.ui.shot.ShotActivity
 
@@ -37,7 +36,6 @@ interface DribbbleComponent : BaseActivityComponent<ShotActivity> {
 
         fun build(): DribbbleComponent
         fun coreComponent(component: CoreComponent): Builder
-        fun coreDataModule(module: CoreDataModule): Builder
         fun dribbbleModule(module: DribbbleModule): Builder
     }
 }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.ViewModelProviders
 import android.content.Context
 import dagger.Module
 import dagger.Provides
-import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
@@ -34,7 +33,7 @@ import io.plaidapp.dribbble.ui.shot.ShotViewModelFactory
 /**
  * Module providing injections for the :dribbble feature module.
  */
-@Module(includes = [DribbbleDataModule::class])
+@Module
 class DribbbleModule(private val activity: ShotActivity, private val shotId: Long) {
 
     @Provides


### PR DESCRIPTION
Tested in an emulator. Would be nice to test in a real device and try some features like login.

## **State of the project before the refactoring**
A Component can be useful for:
- Be injected to an app component.
- Inject modules so that other components that are Subcomponents of it have those modules available.
- Expose dependencies so that other Components that depends on this one can access them.

Before the refactoring, you could find modules in a component defined multiple times. Why?

Since Plaid doesn't structure the Dagger graph with SubComponents. CoreComponent wasn't used as expected. It was never injected to an app component, imported 6 modules and didn't expose any dependency. Those 6 modules created Providers in the CoreComponentDagger generated file that weren't used by any other Component that had CoreComponent as a dependency because those Providers weren't exposed. How can you expose an Object from a Component that can be consumed by others? Exposing the Object in the interface.  

```
interface CoreComponent {
    ...
    fun provideGson(): Gson
}
```

With that, a Component that adds CoreComponent as a dependency can use Gson without having to add it in its list of modules.

Since the XComponent didn't take advantage of the dependencies provided by CoreComponent, Modules were a bit tangled-up because they had to include other Modules (even if they were available elsewhere) just to satisfy its own dependencies.

**Also**, if a Component includes XModule and YModule, if YModule needs XModule, it's not necessary for YModule to include XModule since the Component already includes it. There were few cases like this in the project that have been refactored now. 

## **What is this PR about?**
Just to keep the PR small and simple, it just cleans up the Modules with redundant includes and the Components to use the CoreComponent properly as a dependency, not as a SubComponent. The CoreComponent has been simplified to contain just the Modules that are needed by the rest of the Components.  

## **Next steps**
- Make objects live as long as the component they're in by using Scopes. Issue #573 
- Refactor some Modules that depend on a lot of modules (e.g. SearchModule). 

## **Component lists with Modules**

**CoreComponent**
- CoreDataModule::class


**AboutComponent (Doesn’t add CoreComponent)**
- MarkDownModule
- AboutActivityModule


**DribbbleComponent (adds Core)**


**HomeComponent (adds Core)**
- HomeModule
- - DataManagerModule::class,
- - - DesignerNewsDataModule::class
- - - ProductHuntModule::class
- - SourcesRepositoryModule::class
- - DribbbleDataModule::class
- - OnDataLoadedModule::class
- SharedPreferencesModule


**UpvoteStoryServiceComponent (adds Core)**
- UpvoteStoryServiceModule::class,
- - DesignerNewsDataModule::class
- DesignerNewsDataModule
- SharedPreferencesModule


**StoryComponent (adds Core)**
- StoryModule
- DesignerNewsDataModule::class,
- DataModule::class,
- MarkdownModule::class
- SharedPreferencesModule::class


**LoginComponent (adds Core)**
- DesignerNewsDataModule::class,
- SharedPreferencesModule::class


**SearchComponent (adds Core)**
- SearchModule
- - DribbbleDataModule::class,
- - DesignerNewsDataModule::class,
- - SharedPreferencesModule::class
