### PR TITLE
[DO NOT MERGE] Introduce Coroutine Context provider for ViewModel testability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,10 @@
 buildscript { scriptHandler ->
     apply from: 'repositories.gradle',
             to: scriptHandler
-    ext.versions = [
+  repositories {
+    google()
+  }
+  ext.versions = [
             'compileSdk'         : 28,
             'minSdk'             : 23,
             'targetSdk'          : 28,
@@ -61,7 +64,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-beta05'
+        classpath 'com.android.tools.build:gradle:3.5.0-alpha07'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,7 @@
 buildscript { scriptHandler ->
     apply from: 'repositories.gradle',
             to: scriptHandler
-  repositories {
-    google()
-  }
-  ext.versions = [
+    ext.versions = [
             'compileSdk'         : 28,
             'minSdk'             : 23,
             'targetSdk'          : 28,
@@ -64,7 +61,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-alpha07'
+        classpath 'com.android.tools.build:gradle:3.4.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-beta05'
+        classpath 'com.android.tools.build:gradle:3.5.0-alpha07'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ buildscript { scriptHandler ->
     ]
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0-alpha07'
+        classpath 'com.android.tools.build:gradle:3.4.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
         classpath "io.fabric.tools:gradle:${versions.fabric}"

--- a/core/src/main/java/io/plaidapp/core/data/CoroutinesContextProvider.kt
+++ b/core/src/main/java/io/plaidapp/core/data/CoroutinesContextProvider.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.plaidapp.core.data
 
 import javax.inject.Inject

--- a/core/src/main/java/io/plaidapp/core/data/CoroutinesContextProvider.kt
+++ b/core/src/main/java/io/plaidapp/core/data/CoroutinesContextProvider.kt
@@ -16,12 +16,23 @@
 
 package io.plaidapp.core.data
 
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 /**
  * Provide coroutines context.
+ *
+ * Prefer usage of [CoroutinesDispatcherProvider]
  */
+@Deprecated(
+    message = "Use CoroutinesDispatcherProvider instead",
+    replaceWith = ReplaceWith(
+        expression = "CoroutinesDispatcherProvider",
+        imports = ["io.plaidapp.core.data.CoroutinesDispatcherProvider"]
+    )
+)
+@ObsoleteCoroutinesApi
 data class CoroutinesContextProvider(
     val main: CoroutineContext,
     val computation: CoroutineContext,

--- a/core/src/main/java/io/plaidapp/core/data/CoroutinesContextProvider.kt
+++ b/core/src/main/java/io/plaidapp/core/data/CoroutinesContextProvider.kt
@@ -1,0 +1,16 @@
+package io.plaidapp.core.data
+
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Provide coroutines context.
+ */
+data class CoroutinesContextProvider(
+    val main: CoroutineContext,
+    val computation: CoroutineContext,
+    val io: CoroutineContext
+) {
+
+    @Inject constructor(dispatchers: CoroutinesDispatcherProvider) : this(dispatchers.main, dispatchers.computation, dispatchers.io)
+}

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
+import io.plaidapp.core.data.CoroutinesContextProvider
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
@@ -64,14 +65,14 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
         shotsRepository: ShotsRepository,
         createShotUiModelUseCase: CreateShotUiModelUseCase,
         shareShotInfoUseCase: GetShareShotInfoUseCase,
-        coroutinesDispatcherProvider: CoroutinesDispatcherProvider
+        coroutinesContextProvider: CoroutinesContextProvider
     ): ShotViewModelFactory {
         return ShotViewModelFactory(
             shotId,
             shotsRepository,
             createShotUiModelUseCase,
             shareShotInfoUseCase,
-            coroutinesDispatcherProvider
+            coroutinesContextProvider
         )
     }
 

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -22,7 +22,6 @@ import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
 import io.plaidapp.core.data.CoroutinesContextProvider
-import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
 import io.plaidapp.core.util.FileAuthority

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
@@ -67,7 +67,7 @@ class ShotViewModel @Inject constructor(
 
     fun shareShotRequested() {
         _shotUiModel.value?.let { model ->
-          viewModelScope.launch(contextProvider.io) {
+            viewModelScope.launch(contextProvider.io) {
                 val shareInfo = getShareShotInfo(model)
                 _shareShot.postValue(Event(shareInfo))
             }
@@ -89,7 +89,7 @@ class ShotViewModel @Inject constructor(
     }
 
     private fun processUiModel(shot: Shot) {
-      viewModelScope.launch(contextProvider.main) {
+        viewModelScope.launch(contextProvider.main) {
             val uiModel = createShotUiModel(shot)
             _shotUiModel.value = uiModel
         }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModel.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import io.plaidapp.core.data.CoroutinesContextProvider
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.api.model.Shot
@@ -39,7 +39,7 @@ class ShotViewModel @Inject constructor(
     shotsRepository: ShotsRepository,
     private val createShotUiModel: CreateShotUiModelUseCase,
     private val getShareShotInfo: GetShareShotInfoUseCase,
-    private val dispatcherProvider: CoroutinesDispatcherProvider
+    private val contextProvider: CoroutinesContextProvider
 ) : ViewModel() {
 
     private val _shotUiModel = MutableLiveData<ShotUiModel>()
@@ -67,7 +67,7 @@ class ShotViewModel @Inject constructor(
 
     fun shareShotRequested() {
         _shotUiModel.value?.let { model ->
-            viewModelScope.launch(dispatcherProvider.io) {
+          viewModelScope.launch(contextProvider.io) {
                 val shareInfo = getShareShotInfo(model)
                 _shareShot.postValue(Event(shareInfo))
             }
@@ -89,7 +89,7 @@ class ShotViewModel @Inject constructor(
     }
 
     private fun processUiModel(shot: Shot) {
-        viewModelScope.launch(dispatcherProvider.main) {
+      viewModelScope.launch(contextProvider.main) {
             val uiModel = createShotUiModel(shot)
             _shotUiModel.value = uiModel
         }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModelFactory.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/ui/shot/ShotViewModelFactory.kt
@@ -18,7 +18,7 @@ package io.plaidapp.dribbble.ui.shot
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import io.plaidapp.core.data.CoroutinesContextProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.dribbble.domain.CreateShotUiModelUseCase
 import io.plaidapp.dribbble.domain.GetShareShotInfoUseCase
@@ -32,7 +32,7 @@ class ShotViewModelFactory @Inject constructor(
     private val shotRepository: ShotsRepository,
     private val createShotUiModel: CreateShotUiModelUseCase,
     private val getShareShotInfoUseCase: GetShareShotInfoUseCase,
-    private val dispatcherProvider: CoroutinesDispatcherProvider
+    private val contextProvider: CoroutinesContextProvider
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
@@ -45,7 +45,7 @@ class ShotViewModelFactory @Inject constructor(
             shotRepository,
             createShotUiModel,
             getShareShotInfoUseCase,
-            dispatcherProvider
+            contextProvider
         ) as T
     }
 }

--- a/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
@@ -180,7 +180,7 @@ class ShotViewModelTest {
         whenever(repo.getShot(shotId)).thenReturn(Result.Success(shot))
         if (shareInfo != null) {
             runBlocking {
-              whenever(getShareShotInfoUseCase(any())).thenReturn(shareInfo)
+                whenever(getShareShotInfoUseCase(any())).thenReturn(shareInfo)
             }
         }
         return ShotViewModel(
@@ -190,5 +190,5 @@ class ShotViewModelTest {
             getShareShotInfoUseCase,
             provideFakeCoroutinesContextProvider(context)
         )
-      }
+    }
 }

--- a/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
+++ b/dribbble/src/test/java/io/plaidapp/dribbble/ui/shot/ShotViewModelTest.kt
@@ -71,27 +71,27 @@ class ShotViewModelTest {
         assertNotNull(result)
     }
 
-  @Test
-  @ObsoleteCoroutinesApi
-  fun loadShot_emitsTwoUiModels() {
-    val testContext = TestCoroutineContext()
+    @Test
+    @ObsoleteCoroutinesApi
+    fun loadShot_emitsTwoUiModels() {
+        val testContext = TestCoroutineContext()
 
-    // Here we create the VM that should post 2 objects to LiveData
-    val viewModel = withViewModel(context = testContext)
+        // Here we create the VM that should post 2 objects to LiveData
+        val viewModel = withViewModel(context = testContext)
 
-    // Checking the fast result has been emitted
-    val fastResult: ShotUiModel? = LiveDataTestUtil.getValue(viewModel.shotUiModel)
-    assertNotNull(fastResult)
-    assertTrue(fastResult!!.formattedDescription.isEmpty())
+        // Checking the fast result has been emitted
+        val fastResult: ShotUiModel? = LiveDataTestUtil.getValue(viewModel.shotUiModel)
+        assertNotNull(fastResult)
+        assertTrue(fastResult!!.formattedDescription.isEmpty())
 
-    // Triggering the launch in the method
-    testContext.triggerActions()
+        // Triggering the launch in the method
+        testContext.triggerActions()
 
-    // Checking the slow result has been emitted
-    val slowResult: ShotUiModel? = LiveDataTestUtil.getValue(viewModel.shotUiModel)
-    assertNotNull(slowResult)
-    assertTrue(slowResult!!.formattedDescription.isNotEmpty())
-  }
+        // Checking the slow result has been emitted
+        val slowResult: ShotUiModel? = LiveDataTestUtil.getValue(viewModel.shotUiModel)
+        assertNotNull(slowResult)
+        assertTrue(slowResult!!.formattedDescription.isNotEmpty())
+    }
 
     @Test(expected = IllegalStateException::class)
     fun loadShot_notInRepo() {
@@ -171,24 +171,24 @@ class ShotViewModelTest {
         assertEquals(id, shotId)
     }
 
-  @ExperimentalCoroutinesApi
-  private fun withViewModel(
-      shot: Shot = testShot,
-      shareInfo: ShareShotInfo? = null,
-      context: CoroutineContext = Unconfined
-  ): ShotViewModel {
-    whenever(repo.getShot(shotId)).thenReturn(Result.Success(shot))
-    if (shareInfo != null) {
-      runBlocking {
-        whenever(getShareShotInfoUseCase(any())).thenReturn(shareInfo)
+    @ExperimentalCoroutinesApi
+    private fun withViewModel(
+        shot: Shot = testShot,
+        shareInfo: ShareShotInfo? = null,
+        context: CoroutineContext = Unconfined
+    ): ShotViewModel {
+        whenever(repo.getShot(shotId)).thenReturn(Result.Success(shot))
+        if (shareInfo != null) {
+            runBlocking {
+              whenever(getShareShotInfoUseCase(any())).thenReturn(shareInfo)
+            }
+        }
+        return ShotViewModel(
+            shotId,
+            repo,
+            createShotUiModel,
+            getShareShotInfoUseCase,
+            provideFakeCoroutinesContextProvider(context)
+        )
       }
-    }
-    return ShotViewModel(
-        shotId,
-        repo,
-        createShotUiModel,
-        getShareShotInfoUseCase,
-        provideFakeCoroutinesContextProvider(context)
-    )
-  }
 }

--- a/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
+++ b/test_shared/src/main/java/io/plaidapp/test/shared/FakeAppInjection.kt
@@ -16,8 +16,20 @@
 
 package io.plaidapp.test.shared
 
+import io.plaidapp.core.data.CoroutinesContextProvider
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers.Unconfined
+import kotlin.coroutines.CoroutineContext
 
-fun provideFakeCoroutinesDispatcherProvider(): CoroutinesDispatcherProvider =
-    CoroutinesDispatcherProvider(Unconfined, Unconfined, Unconfined)
+fun provideFakeCoroutinesDispatcherProvider(dispatcher: CoroutineDispatcher = Unconfined): CoroutinesDispatcherProvider =
+    CoroutinesDispatcherProvider(dispatcher, dispatcher, dispatcher)
+
+/**
+ * Use CoroutineContext when the use of TestCoroutineContext is necessary for testing,
+ * replace with TestCoroutineDispatcher when available.
+ *
+ * @see https://github.com/Kotlin/kotlinx.coroutines/pull/890
+ */
+fun provideFakeCoroutinesContextProvider(context: CoroutineContext = Unconfined): CoroutinesContextProvider =
+    CoroutinesContextProvider(context, context, context)


### PR DESCRIPTION
## DO NOT MERGE

In #655 we need to be able to control the execution of coroutines in a `ViewModel` in order to assert the expected "immediate" behaviour before the suspended operation would overwrite this value.

Since traditional test dispatchers provided defer to "immediate" execution using `Dispatchers.Unconfined`, this cannot be directly achieved.

This pull request, demonstrates how we can use a similar behaviour to provide a `CoroutineContext` instead of `CoroutineDispatcher` to test `ViewModel`'s behaviour, the test has been written by @manuelvicnt in #655, I've only demonstrated here how to use `TestCoroutineContext`.

Adversely, I would actually recommend against this solution, since it introduces confusion as to whether one should use `CoroutineContext` or `CoroutineDispatcher` and does not clearly identify the nuances between them.

Furthermore, a [pull request](https://github.com/Kotlin/kotlinx.coroutines/pull/890) from @objcode proposes a better implementation of `TestCoroutineContext`, splitting it up into `TestCoroutineDispatcher` and accompanying `TestCoroutineScope`, properly respecting the hierarchical nature of coroutine execution.

It would probably be better to wait for this to become available in `coroutine-test` rather than going with this implementation, but I have no idea how long that might be.

### Consideration
In our workflow we conside a pull request to be invalid if we don't provide a meme to accompany it, so here is mine 😄 

![](https://media.giphy.com/media/tZpGRRMUoXgeQ/giphy.gif)