### PR TITLE
Use Scopes to make objects have Component lifecycle

### DIFF
--- a/about/src/main/java/io/plaidapp/about/dagger/AboutActivityModule.kt
+++ b/about/src/main/java/io/plaidapp/about/dagger/AboutActivityModule.kt
@@ -29,11 +29,9 @@ import io.plaidapp.core.dagger.scope.FeatureScope
 @Module class AboutActivityModule(private val activity: AboutActivity) {
 
     @Provides
-    @FeatureScope
     fun provideContext(): AboutActivity = activity
 
     @Provides
-    @FeatureScope
     fun provideResources(): Resources = activity.resources
 
     @Provides

--- a/about/src/main/java/io/plaidapp/about/dagger/AboutActivityModule.kt
+++ b/about/src/main/java/io/plaidapp/about/dagger/AboutActivityModule.kt
@@ -21,7 +21,7 @@ import dagger.Module
 import dagger.Provides
 import io.plaidapp.about.ui.AboutActivity
 import io.plaidapp.about.ui.AboutStyler
-import io.plaidapp.core.dagger.scope.ModuleScope
+import io.plaidapp.core.dagger.scope.FeatureScope
 
 /**
  * Dagger module providing stuff for [AboutActivity].
@@ -29,14 +29,14 @@ import io.plaidapp.core.dagger.scope.ModuleScope
 @Module class AboutActivityModule(private val activity: AboutActivity) {
 
     @Provides
-    @ModuleScope
+    @FeatureScope
     fun provideContext(): AboutActivity = activity
 
     @Provides
-    @ModuleScope
+    @FeatureScope
     fun provideResources(): Resources = activity.resources
 
     @Provides
-    @ModuleScope
+    @FeatureScope
     fun provideAboutStyler(): AboutStyler = AboutStyler(activity)
 }

--- a/about/src/main/java/io/plaidapp/about/dagger/AboutComponent.kt
+++ b/about/src/main/java/io/plaidapp/about/dagger/AboutComponent.kt
@@ -21,13 +21,13 @@ import dagger.Component
 import io.plaidapp.about.ui.AboutActivity
 import io.plaidapp.core.dagger.BaseActivityComponent
 import io.plaidapp.core.dagger.MarkdownModule
-import io.plaidapp.core.dagger.scope.ModuleScope
+import io.plaidapp.core.dagger.scope.FeatureScope
 
 /**
  * Dagger component for `about` feature module.
  */
 @Component(modules = [AboutActivityModule::class, MarkdownModule::class])
-@ModuleScope
+@FeatureScope
 interface AboutComponent : BaseActivityComponent<AboutActivity> {
 
     @Component.Builder

--- a/app/src/main/java/io/plaidapp/dagger/HomeComponent.kt
+++ b/app/src/main/java/io/plaidapp/dagger/HomeComponent.kt
@@ -21,6 +21,7 @@ import dagger.Component
 import io.plaidapp.core.dagger.BaseActivityComponent
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.SharedPreferencesModule
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.ui.HomeActivity
 
 /**
@@ -30,6 +31,7 @@ import io.plaidapp.ui.HomeActivity
         modules = [HomeModule::class, SharedPreferencesModule::class],
         dependencies = [CoreComponent::class]
 )
+@FeatureScope
 interface HomeComponent : BaseActivityComponent<HomeActivity> {
 
     @Component.Builder

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
@@ -21,6 +21,7 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Component
 import okhttp3.OkHttpClient
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
 
 /**
  * Component providing application wide singletons.
@@ -28,6 +29,7 @@ import retrofit2.converter.gson.GsonConverterFactory
  * Activity.coreComponent extension function.
  */
 @Component(modules = [CoreDataModule::class])
+@Singleton
 interface CoreComponent {
 
     @Component.Builder interface Builder {

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreDataModule.kt
@@ -24,6 +24,7 @@ import io.plaidapp.core.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
 
 /**
  * Dagger module to provide core data functionality.
@@ -48,9 +49,11 @@ class CoreDataModule {
     @Provides
     fun provideCallAdapterFactory(): CoroutineCallAdapterFactory = CoroutineCallAdapterFactory()
 
+    @Singleton
     @Provides
     fun provideGson(): Gson = Gson()
 
+    @Singleton
     @Provides
     fun provideGsonConverterFactory(gson: Gson): GsonConverterFactory =
         GsonConverterFactory.create(gson)

--- a/core/src/main/java/io/plaidapp/core/dagger/DataManagerModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/DataManagerModule.kt
@@ -19,6 +19,7 @@ package io.plaidapp.core.dagger
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.DataLoadingSubject
 import io.plaidapp.core.data.DataManager
 import io.plaidapp.core.data.prefs.SourcesRepository
@@ -36,6 +37,7 @@ class DataManagerModule {
     private lateinit var manager: DataManager
 
     @Provides
+    @FeatureScope
     fun provideDataManager(
         loadStories: LoadStoriesUseCase,
         searchStories: SearchStoriesUseCase,
@@ -51,6 +53,7 @@ class DataManagerModule {
     )
 
     @Provides
+    @FeatureScope
     fun provideDataLoadingSubject(
         loadStories: LoadStoriesUseCase,
         loadPosts: LoadPostsUseCase,

--- a/core/src/main/java/io/plaidapp/core/dagger/MarkdownModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/MarkdownModule.kt
@@ -21,14 +21,18 @@ import `in`.uncod.android.bypass.Markdown
 import android.util.DisplayMetrics
 import dagger.Module
 import dagger.Provides
+import io.plaidapp.core.dagger.scope.FeatureScope
 
 /**
  * Provide [Markdown] to this app's components.
  */
-@Module class MarkdownModule constructor(
+@Module
+class MarkdownModule constructor(
     private val displayMetrics: DisplayMetrics,
     private val options: Bypass.Options = Bypass.Options()
 ) {
 
-    @Provides fun provideMarkdown(): Markdown = Bypass(displayMetrics, options)
+    @Provides
+    @FeatureScope
+    fun provideMarkdown(): Markdown = Bypass(displayMetrics, options)
 }

--- a/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/ProductHuntModule.kt
@@ -21,6 +21,7 @@ import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.BuildConfig
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.api.DeEnvelopingConverter
 import io.plaidapp.core.producthunt.data.ProductHuntRemoteDataSource
@@ -38,6 +39,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class ProductHuntModule {
 
     @Provides
+    @FeatureScope
     fun provideProductHuntRepository(
         remoteDataSource: ProductHuntRemoteDataSource,
         dispatcherProvider: CoroutinesDispatcherProvider
@@ -54,6 +56,7 @@ class ProductHuntModule {
     }
 
     @Provides
+    @FeatureScope
     fun provideProductHuntService(
         @ProductHuntApi okhttpClient: Lazy<OkHttpClient>,
         converterFactory: GsonConverterFactory,

--- a/core/src/main/java/io/plaidapp/core/dagger/SharedPreferencesModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/SharedPreferencesModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import dagger.Module
 import dagger.Provides
+import io.plaidapp.core.dagger.scope.FeatureScope
 
 /**
  * Provide [SharedPreferences] to this app's components.
@@ -27,7 +28,9 @@ import dagger.Provides
 @Module
 open class SharedPreferencesModule(val context: Context, val name: String) {
 
-    @Provides fun provideSharedPreferences(): SharedPreferences {
+    @Provides
+    @FeatureScope
+    fun provideSharedPreferences(): SharedPreferences {
         return context.applicationContext.getSharedPreferences(name, Context.MODE_PRIVATE)
     }
 }

--- a/core/src/main/java/io/plaidapp/core/dagger/SourcesRepositoryModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/SourcesRepositoryModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.R
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.data.SourceItem
 import io.plaidapp.core.data.prefs.SourcesLocalDataSource
@@ -36,6 +37,7 @@ import io.plaidapp.core.producthunt.data.ProductHuntSourceItem
 class SourcesRepositoryModule {
 
     @Provides
+    @FeatureScope
     fun provideSourceRepository(
         context: Context,
         dispatcherProvider: CoroutinesDispatcherProvider

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/DesignerNewsDataModule.kt
@@ -24,6 +24,7 @@ import dagger.Module
 import dagger.Provides
 import io.plaidapp.core.BuildConfig
 import io.plaidapp.core.dagger.DesignerNewsApi
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.api.DeEnvelopingConverter
 import io.plaidapp.core.designernews.data.api.ClientAuthInterceptor
 import io.plaidapp.core.designernews.data.api.DesignerNewsSearchConverter
@@ -45,6 +46,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class DesignerNewsDataModule {
 
     @Provides
+    @FeatureScope
     fun provideLoginRepository(
         localSource: LoginLocalDataSource,
         remoteSource: LoginRemoteDataSource
@@ -52,6 +54,7 @@ class DesignerNewsDataModule {
         LoginRepository.getInstance(localSource, remoteSource)
 
     @Provides
+    @FeatureScope
     fun provideAuthTokenLocalDataSource(
         sharedPreferences: SharedPreferences
     ): AuthTokenLocalDataSource =
@@ -69,6 +72,7 @@ class DesignerNewsDataModule {
     }
 
     @Provides
+    @FeatureScope
     fun provideDesignerNewsService(
         @DesignerNewsApi client: Lazy<OkHttpClient>,
         gson: Gson
@@ -85,12 +89,14 @@ class DesignerNewsDataModule {
     }
 
     @Provides
+    @FeatureScope
     fun provideStoriesRepository(
         storiesRemoteDataSource: StoriesRemoteDataSource
     ): StoriesRepository =
         StoriesRepository.getInstance(storiesRemoteDataSource)
 
     @Provides
+    @FeatureScope
     fun provideStoriesRemoteDataSource(service: DesignerNewsService): StoriesRemoteDataSource {
         return StoriesRemoteDataSource.getInstance(service)
     }

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/UpvoteStoryServiceComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/UpvoteStoryServiceComponent.kt
@@ -20,6 +20,7 @@ import dagger.Component
 import io.plaidapp.core.dagger.BaseServiceComponent
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.SharedPreferencesModule
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
 
 /**
@@ -33,6 +34,7 @@ import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
     ],
     dependencies = [CoreComponent::class]
 )
+@FeatureScope
 interface UpvoteStoryServiceComponent : BaseServiceComponent<UpvoteStoryService> {
 
     @Component.Builder

--- a/core/src/main/java/io/plaidapp/core/dagger/designernews/UpvoteStoryServiceModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/designernews/UpvoteStoryServiceModule.kt
@@ -20,17 +20,20 @@ import android.app.Service
 import android.content.Context
 import dagger.Module
 import dagger.Provides
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.designernews.data.votes.UpvoteStoryService
 
 /**
  * Dagger module for [UpvoteStoryService].
  */
-@Module(includes = [DesignerNewsDataModule::class])
+@Module
 class UpvoteStoryServiceModule(private val service: UpvoteStoryService) {
 
     @Provides
+    @FeatureScope
     fun context(): Context = service
 
     @Provides
+    @FeatureScope
     fun service(): Service = service
 }

--- a/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/dribbble/DribbbleDataModule.kt
@@ -20,6 +20,7 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.dribbble.data.search.DribbbleSearchConverter
@@ -35,16 +36,19 @@ import retrofit2.Retrofit
 class DribbbleDataModule {
 
     @Provides
+    @FeatureScope
     fun provideShotsRepository(
         remoteDataSource: SearchRemoteDataSource,
         dispatcherProvider: CoroutinesDispatcherProvider
     ) = ShotsRepository.getInstance(remoteDataSource, dispatcherProvider)
 
     @Provides
+    @FeatureScope
     fun provideConverterFactory(): DribbbleSearchConverter.Factory =
         DribbbleSearchConverter.Factory()
 
     @Provides
+    @FeatureScope
     fun provideDribbbleSearchService(
         client: Lazy<OkHttpClient>,
         converterFactory: DribbbleSearchConverter.Factory,

--- a/core/src/main/java/io/plaidapp/core/dagger/scope/FeatureScope.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/scope/FeatureScope.kt
@@ -24,4 +24,4 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
  */
 @Scope
 @Retention(RUNTIME)
-annotation class ModuleScope
+annotation class FeatureScope

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/DataModule.kt
@@ -22,6 +22,7 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Lazy
 import dagger.Module
 import dagger.Provides
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.api.DeEnvelopingConverter
 import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.database.DesignerNewsDatabase
@@ -37,6 +38,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class DataModule {
 
     @Provides
+    @FeatureScope
     fun provideDesignerNewsService(
         client: Lazy<OkHttpClient>,
         gson: Gson
@@ -52,6 +54,7 @@ class DataModule {
     }
 
     @Provides
+    @FeatureScope
     fun provideLoggedInUserDao(context: Context): LoggedInUserDao {
         return DesignerNewsDatabase.getInstance(context).loggedInUserDao()
     }

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/LoginComponent.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/LoginComponent.kt
@@ -21,6 +21,7 @@ import io.plaidapp.core.dagger.BaseActivityComponent
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.designernews.ui.login.LoginActivity
 
 /**
@@ -33,6 +34,7 @@ import io.plaidapp.designernews.ui.login.LoginActivity
     ],
     dependencies = [CoreComponent::class]
 )
+@FeatureScope
 interface LoginComponent : BaseActivityComponent<LoginActivity> {
 
     interface Builder {

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryComponent.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryComponent.kt
@@ -22,6 +22,7 @@ import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.MarkdownModule
 import io.plaidapp.core.dagger.SharedPreferencesModule
 import io.plaidapp.core.dagger.designernews.DesignerNewsDataModule
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.designernews.ui.story.StoryActivity
 
 /**
@@ -36,6 +37,7 @@ import io.plaidapp.designernews.ui.story.StoryActivity
         StoryModule::class],
     dependencies = [CoreComponent::class]
 )
+@FeatureScope
 interface StoryComponent : BaseActivityComponent<StoryActivity> {
 
     @Component.Builder

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/StoryModule.kt
@@ -19,6 +19,7 @@ package io.plaidapp.designernews.dagger
 import androidx.lifecycle.ViewModelProviders
 import dagger.Module
 import dagger.Provides
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.designernews.data.api.DesignerNewsService
 import io.plaidapp.designernews.data.comments.CommentsRemoteDataSource
@@ -79,18 +80,22 @@ class StoryModule(private val storyId: Long, private val activity: StoryActivity
         )
 
     @Provides
+    @FeatureScope
     fun provideUserRepository(dataSource: UserRemoteDataSource): UserRepository =
-        UserRepository.getInstance(dataSource)
+        UserRepository(dataSource)
 
     @Provides
+    @FeatureScope
     fun provideCommentsRemoteDataSource(service: DesignerNewsService): CommentsRemoteDataSource =
-        CommentsRemoteDataSource.getInstance(service)
+        CommentsRemoteDataSource(service)
 
     @Provides
+    @FeatureScope
     fun provideVotesRepository(remoteDataSource: VotesRemoteDataSource): VotesRepository =
-        VotesRepository.getInstance(remoteDataSource)
+        VotesRepository(remoteDataSource)
 
     @Provides
+    @FeatureScope
     fun provideCommentsRepository(dataSource: CommentsRemoteDataSource): CommentsRepository =
-        CommentsRepository.getInstance(dataSource)
+        CommentsRepository(dataSource)
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRemoteDataSource.kt
@@ -91,14 +91,4 @@ class CommentsRemoteDataSource(private val service: DesignerNewsService) {
         }
         return Result.Error(IOException("Error posting comment ${response.code()} ${response.message()}"))
     }
-
-    companion object {
-        @Volatile private var INSTANCE: CommentsRemoteDataSource? = null
-
-        fun getInstance(service: DesignerNewsService): CommentsRemoteDataSource {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: CommentsRemoteDataSource(service).also { INSTANCE = it }
-            }
-        }
-    }
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/comments/CommentsRepository.kt
@@ -62,17 +62,4 @@ class CommentsRepository(private val remoteDataSource: CommentsRemoteDataSource)
             userId = userId
         )
     }
-
-    companion object {
-        @Volatile
-        private var INSTANCE: CommentsRepository? = null
-
-        fun getInstance(
-            remoteDataSource: CommentsRemoteDataSource
-        ): CommentsRepository {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: CommentsRepository(remoteDataSource).also { INSTANCE = it }
-            }
-        }
-    }
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRepository.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/users/UserRepository.kt
@@ -50,15 +50,4 @@ class UserRepository(private val dataSource: UserRemoteDataSource) {
             result.data.forEach { cachedUsers[it.id] = it }
         }
     }
-
-    companion object {
-        @Volatile
-        private var INSTANCE: UserRepository? = null
-
-        fun getInstance(dataSource: UserRemoteDataSource): UserRepository {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: UserRepository(dataSource).also { INSTANCE = it }
-            }
-        }
-    }
 }

--- a/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRepository.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/data/votes/VotesRepository.kt
@@ -32,16 +32,4 @@ class VotesRepository(private val remoteDataSource: VotesRemoteDataSource) {
         // TODO save the response in the database
         return remoteDataSource.upvoteComment(commentId, userId)
     }
-
-    companion object {
-        @Volatile
-        private var INSTANCE: VotesRepository? = null
-
-        fun getInstance(remoteDataSource: VotesRemoteDataSource): VotesRepository {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE
-                    ?: VotesRepository(remoteDataSource).also { INSTANCE = it }
-            }
-        }
-    }
 }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleComponent.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleComponent.kt
@@ -20,6 +20,7 @@ import dagger.Component
 import io.plaidapp.core.dagger.BaseActivityComponent
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.dribbble.DribbbleDataModule
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.dribbble.ui.shot.ShotActivity
 
 /**
@@ -29,6 +30,7 @@ import io.plaidapp.dribbble.ui.shot.ShotActivity
     modules = [DribbbleModule::class, DribbbleDataModule::class],
     dependencies = [CoreComponent::class]
 )
+@FeatureScope
 interface DribbbleComponent : BaseActivityComponent<ShotActivity> {
 
     @Component.Builder

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModelProviders
 import android.content.Context
 import dagger.Module
 import dagger.Provides
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
@@ -39,6 +40,7 @@ import io.plaidapp.dribbble.ui.shot.ShotViewModelFactory
 class DribbbleModule(private val activity: ShotActivity, private val shotId: Long) {
 
     @Provides
+    @FeatureScope
     fun provideContext(): Context = activity
 
     @Provides
@@ -47,6 +49,7 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     }
 
     @Provides
+    @FeatureScope
     fun chromeFader(): ElasticDragDismissFrameLayout.SystemChromeFader {
         return object : ElasticDragDismissFrameLayout.SystemChromeFader(activity) {
             override fun onDragDismissed() {
@@ -56,6 +59,7 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     }
 
     @Provides
+    @FeatureScope
     fun htmlParser() = HtmlParser()
 
     @Provides
@@ -75,5 +79,6 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     }
 
     @Provides
+    @FeatureScope
     fun fileAuthority() = FileAuthority(BuildConfig.FILES_AUTHORITY)
 }

--- a/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/dagger/DribbbleModule.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.ViewModelProviders
 import android.content.Context
 import dagger.Module
 import dagger.Provides
-import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.core.data.CoroutinesDispatcherProvider
 import io.plaidapp.core.dribbble.data.ShotsRepository
 import io.plaidapp.core.ui.widget.ElasticDragDismissFrameLayout
@@ -40,7 +39,6 @@ import io.plaidapp.dribbble.ui.shot.ShotViewModelFactory
 class DribbbleModule(private val activity: ShotActivity, private val shotId: Long) {
 
     @Provides
-    @FeatureScope
     fun provideContext(): Context = activity
 
     @Provides
@@ -49,7 +47,6 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     }
 
     @Provides
-    @FeatureScope
     fun chromeFader(): ElasticDragDismissFrameLayout.SystemChromeFader {
         return object : ElasticDragDismissFrameLayout.SystemChromeFader(activity) {
             override fun onDragDismissed() {
@@ -59,7 +56,6 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     }
 
     @Provides
-    @FeatureScope
     fun htmlParser() = HtmlParser()
 
     @Provides
@@ -79,6 +75,5 @@ class DribbbleModule(private val activity: ShotActivity, private val shotId: Lon
     }
 
     @Provides
-    @FeatureScope
     fun fileAuthority() = FileAuthority(BuildConfig.FILES_AUTHORITY)
 }

--- a/search/src/main/java/io/plaidapp/search/dagger/SearchComponent.kt
+++ b/search/src/main/java/io/plaidapp/search/dagger/SearchComponent.kt
@@ -21,12 +21,14 @@ import dagger.Component
 import io.plaidapp.core.dagger.BaseActivityComponent
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.SharedPreferencesModule
+import io.plaidapp.core.dagger.scope.FeatureScope
 import io.plaidapp.search.ui.SearchActivity
 
 /**
  * Dagger component for the [SearchActivity].
  */
 @Component(modules = [SearchModule::class], dependencies = [CoreComponent::class])
+@FeatureScope
 interface SearchComponent : BaseActivityComponent<SearchActivity> {
 
     @Component.Builder


### PR DESCRIPTION
## Theory behind the changes
With scopes, you can keep a single instance of a class as long as that scope exists. The Component defines the Scope that is used in its dependencies with an annotation in its interface declaration.

```
@Component(modules = [CoreDataModule::class])
@Singleton
interface CoreComponent {}
```

For this to work, the Component needs to be annotated with a scope. Then, the modules that the component includes must be also annotated with that particular scope. Let's take a look at an example:

In Plaid, CoreComponent acts as the BaseComponent that most components depends on. Since there's only an instance of the CoreComponent in the app lifecycle (in our case created in PlaidApplication.kt), the objects created with that Component will live until the application dies. With that definition, we could call that Singleton objects. That's why the CoreComponent is marked with the `@Singleton` annotation, the modules using `@Singleton` in their `@Provide` methods will make that object live as long as the process is alive. For example, we can see the Gson object we create in the CoreData module:

```
    @Singleton
    @Provides
    fun provideGson(): Gson = Gson()
```

Other objects that this module provides, for example a base implementation of a `OkHttpClient` doesn't have the `@Singleton` annotation because we want to create a new object every time that dependency gets injected. We don't want to reuse `OkHttpClient` because each of them have a different use case.

Same can be extrapolated to `@FeatureScope`, the object will live as long as the component is in memory. For example, when a user is going to log in, we create a new LoginComponent. When the user is not in the login flow anymore, that component gets destroyed. And when there's a new login the Component is recreated again. In this case, LoginComponents are independent and information from one login doesn't leak to the other one.

**Important:** One component can consume objects from other scopes that it depends on. For example, LoginComponent with `@FeatureScope` can use `Gson` that is provided with a `@Singleton` scope because LoginComponent depends on CoreComponent. However, it cannot provide objects with a different scope it's annotated with. Since LoginComponent is annotated with `@FeatureScope` it can provide objects that live that long, but it cannot provide an object with a `@Singleton` scope because it's not annotated with it.

Notice that the name we give to Scopes are not useful. Even if we called the `Singleton` scope something like `ProcessLifecycle` scope. It'd behave in the same way. It comes down to: there will be just one instance of that object for that Component. 

## Should something live as long as the Component it is in?
In this PR we followed this pattern:

**Should**
- Gson
- GsonConverterFactory
- Context
- Resources
- Stylers
- Markdown
- Repositories
- DataManagers
- DataSources
- Services
- SharedPreferences
- Daos
- ConverterFactories
- ChromeFader
- FileAuthority
- Subjects??

**Shouldn't**
- OkHttpClient
- OkInterceptors
- CallAdapterFactory
- ViewModel
- ViewModelFactory
- DataLoaded