### PR TITLE
Add SupervisorScope to LoadSearchDataUseCase

### DIFF
--- a/search/src/main/java/io/plaidapp/search/domain/LoadSearchDataUseCase.kt
+++ b/search/src/main/java/io/plaidapp/search/domain/LoadSearchDataUseCase.kt
@@ -22,12 +22,10 @@ import io.plaidapp.core.data.PlaidItem
 import io.plaidapp.core.data.Result
 import io.plaidapp.core.interfaces.SearchDataSourceFactory
 import io.plaidapp.core.ui.getPlaidItemsForDisplay
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.supervisorScope
 
 /**
  * Searches for a query in a list of data sources. Exposes the results of the search in a LiveData,
@@ -46,20 +44,19 @@ class LoadSearchDataUseCase(
         get() = _searchResult
 
     suspend operator fun invoke() {
-        val job = SupervisorJob(coroutineContext[Job])
-        val scope = CoroutineScope(job)
         val deferredJobs = mutableListOf<Deferred<Unit>>()
-
-        dataSources.forEach {
-            deferredJobs.add(scope.async {
-                val result = it.loadMore()
-                if (result is Result.Success) {
-                    val oldItems = _searchResult.value.orEmpty().toMutableList()
-                    val searchResult = getPlaidItemsForDisplay(oldItems, result.data)
-                    _searchResult.postValue(searchResult)
-                }
-            })
+        supervisorScope {
+            dataSources.forEach {
+                deferredJobs.add(async {
+                    val result = it.loadMore()
+                    if (result is Result.Success) {
+                        val oldItems = _searchResult.value.orEmpty().toMutableList()
+                        val searchResult = getPlaidItemsForDisplay(oldItems, result.data)
+                        _searchResult.postValue(searchResult)
+                    }
+                })
+            }
         }
-        deferredJobs.forEach { it.await() }
+        deferredJobs.awaitAll()
     }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The previous implementation used a custom `CoroutineScope` that shouldn't be used as per https://medium.com/@elizarov/coroutine-context-and-scope-c8b255d59055

This uses `supervisorScope` instead. 

As per Sean McQuillan:

If you're trying to make a function that launches a coroutine that's intended to live longer than the caller, then taking CoroutineScope as an argument (or having it as a member e.g. viewModelScope) is the right way to structure that
If you're trying to make a function that launches a coroutine that will follow the rules of structured concurrency, then you can use coroutineScope {} and supervisorScope {}

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
