### PR TITLE
Fix eternal loading progress #719 #697

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -62,6 +62,14 @@
             android:indeterminateTintMode="src_in" />
 
         <ViewStub
+            android:id="@+id/stub_no_data"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_margin="@dimen/spacing_huge"
+            android:layout="@layout/no_filters" />
+
+        <ViewStub
             android:id="@+id/stub_no_filters"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="add">Add</string>
     <string name="edit">Edit</string>
     <string name="no_filters_selected">No filters selected, press the filter button above (<annotation src="@drawable/ic_filter_small">&#2228;</annotation>)\n<i><annotation foregroundColor="@color/text_secondary_light">or swipe from the&#160;right</annotation></i></string>
+    <string name="no_data">No data, problem with server, press the filter button above (<annotation src="@drawable/ic_filter_small">&#2228;</annotation>)\n<i><annotation foregroundColor="@color/text_secondary_light">or swipe from the&#160;right</annotation></i></string>
 
     <!--searchable label-->
     <string name="search_hint">Search Dribbble &amp; Designer News</string>

--- a/core/src/main/java/io/plaidapp/core/ui/filter/FilterAdapter.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/filter/FilterAdapter.kt
@@ -65,8 +65,8 @@ class FilterAdapter : ListAdapter<SourceUiModel, FilterViewHolder>(sourceUiModel
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): FilterViewHolder {
         val holder = FilterViewHolder(
-                LayoutInflater.from(viewGroup.context)
-                        .inflate(R.layout.filter_item, viewGroup, false)
+            LayoutInflater.from(viewGroup.context)
+                .inflate(R.layout.filter_item, viewGroup, false)
         )
         holder.itemView.setOnClickListener {
             val position = holder.adapterPosition
@@ -108,5 +108,13 @@ class FilterAdapter : ListAdapter<SourceUiModel, FilterViewHolder>(sourceUiModel
     override fun onItemDismiss(position: Int) {
         val uiModel = getItem(position)
         uiModel.onSourceDismissed(uiModel)
+    }
+
+    fun getEnabledFilterCount(): Int {
+        var count = 0
+        currentList.map {
+            if (it.active) count = count.inc()
+        }
+        return count
     }
 }

--- a/core/src/main/java/io/plaidapp/core/ui/recyclerview/InfiniteScrollListener.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/recyclerview/InfiniteScrollListener.kt
@@ -37,12 +37,16 @@ abstract class InfiniteScrollListener(
         val totalItemCount = layoutManager.itemCount
         val firstVisibleItem = layoutManager.findFirstVisibleItemPosition()
 
-        if (totalItemCount - visibleItemCount <= firstVisibleItem + VISIBLE_THRESHOLD) {
+        if (totalItemCount - visibleItemCount <= firstVisibleItem + VISIBLE_THRESHOLD && totalItemCount > 0) {
             recyclerView.post(loadMoreRunnable)
+        } else {
+            onStopLoading()
         }
     }
 
     abstract fun onLoadMore()
+
+    abstract fun onStopLoading()
 
     abstract fun isDataLoading(): Boolean
 

--- a/search/src/main/java/io/plaidapp/search/domain/LoadSearchDataUseCase.kt
+++ b/search/src/main/java/io/plaidapp/search/domain/LoadSearchDataUseCase.kt
@@ -57,6 +57,7 @@ class LoadSearchDataUseCase(
                 })
             }
         }
+        if (_searchResult.value == null) _searchResult.postValue(emptyList())
         deferredJobs.awaitAll()
     }
 }

--- a/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
+++ b/search/src/main/java/io/plaidapp/search/ui/SearchActivity.kt
@@ -169,6 +169,8 @@ class SearchActivity : AppCompatActivity() {
                 override fun isDataLoading(): Boolean {
                     return viewModel.searchProgress.value?.isLoading ?: false
                 }
+
+                override fun onStopLoading() {}
             })
             setHasFixedSize(true)
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fix eternal refreshing and empty state in HomeActivity
Fix eternal refreshing in Search
Feat placeholder when data are not available same like for no filters

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When only "Product Hunt" filter was selected and no data was available from the response, the progress was showing infinitely, also function onLoadMore in InfiniteScrollListener was refreshing infinitely when data was not available.
https://github.com/android/plaid/issues/719

if searched data was not available, LiveData didn't trigger because data loading function didn't assign an empty list to searchResult
https://github.com/android/plaid/issues/697

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
![719](https://user-images.githubusercontent.com/25232443/59965857-bda2ef80-9513-11e9-8f73-0832cb632232.png)
