### PR TITLE
Added modifiableForEach extension method that allows for in place ListModification during traversal

### DIFF
--- a/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
@@ -25,7 +25,7 @@ import androidx.dynamicanimation.animation.SpringAnimation.TRANSLATION_Y
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.RecyclerView
 import io.plaidapp.core.util.listenForAllSpringsEnd
-import io.plaidapp.core.util.removableForEach
+import io.plaidapp.core.util.onEach
 import io.plaidapp.core.util.spring
 
 /**
@@ -109,10 +109,10 @@ open class SlideInItemAnimator @JvmOverloads constructor(
     }
 
     override fun endAnimations() {
-        pendingAdds.removableForEach(::endPendingAdd)
-        runningAdds.removableForEach(::endRunningAdd)
-        pendingMoves.removableForEach(::endPendingMove)
-        runningMoves.removableForEach(::endRunningMove)
+        pendingAdds.onEach(::endPendingAdd)
+        runningAdds.onEach(::endRunningAdd)
+        pendingMoves.onEach(::endPendingMove)
+        runningMoves.onEach(::endRunningMove)
         super.endAnimations()
     }
 

--- a/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
@@ -25,7 +25,7 @@ import androidx.dynamicanimation.animation.SpringAnimation.TRANSLATION_Y
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.RecyclerView
 import io.plaidapp.core.util.listenForAllSpringsEnd
-import io.plaidapp.core.util.modifiableForEach
+import io.plaidapp.core.util.removableForEach
 import io.plaidapp.core.util.spring
 
 /**
@@ -109,10 +109,10 @@ open class SlideInItemAnimator @JvmOverloads constructor(
     }
 
     override fun endAnimations() {
-        pendingAdds.modifiableForEach(::endPendingAdd)
-        runningAdds.modifiableForEach(::endRunningAdd)
-        pendingMoves.modifiableForEach(::endPendingMove)
-        runningMoves.modifiableForEach(::endRunningMove)
+        pendingAdds.removableForEach(::endPendingAdd)
+        runningAdds.removableForEach(::endRunningAdd)
+        pendingMoves.removableForEach(::endPendingMove)
+        runningMoves.removableForEach(::endRunningMove)
         super.endAnimations()
     }
 

--- a/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
@@ -25,6 +25,7 @@ import androidx.dynamicanimation.animation.SpringAnimation.TRANSLATION_Y
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.RecyclerView
 import io.plaidapp.core.util.listenForAllSpringsEnd
+import io.plaidapp.core.util.modifiableForEach
 import io.plaidapp.core.util.spring
 
 /**
@@ -108,10 +109,10 @@ open class SlideInItemAnimator @JvmOverloads constructor(
     }
 
     override fun endAnimations() {
-        pendingAdds.forEach(::endPendingAdd)
-        runningAdds.forEach(::endRunningAdd)
-        pendingMoves.forEach(::endPendingMove)
-        runningMoves.forEach(::endRunningMove)
+        pendingAdds.modifiableForEach(::endPendingAdd)
+        runningAdds.modifiableForEach(::endRunningAdd)
+        pendingMoves.modifiableForEach(::endPendingMove)
+        runningMoves.modifiableForEach(::endRunningMove)
         super.endAnimations()
     }
 

--- a/core/src/main/java/io/plaidapp/core/util/Extensions.kt
+++ b/core/src/main/java/io/plaidapp/core/util/Extensions.kt
@@ -39,7 +39,7 @@ val <T> T.exhaustive: T
  * A for each loop where traversal is backed by an [MutableIterator] allowing for removal
  * during iteration.
  */
-inline fun <T> MutableIterable<T>.removableForEach(action: (T) -> Unit) {
+inline fun <T> MutableIterable<T>.onEach(action: (T) -> Unit) {
     val iterator = iterator()
     while (iterator.hasNext()) action(iterator.next())
 }

--- a/core/src/main/java/io/plaidapp/core/util/Extensions.kt
+++ b/core/src/main/java/io/plaidapp/core/util/Extensions.kt
@@ -34,3 +34,13 @@ package io.plaidapp.core.util
  */
 val <T> T.exhaustive: T
     get() = this
+
+/**
+ * A for each loop where traversal is backed by an [Iterator] allowing for list modification
+ * in place.
+ */
+inline fun <T> Iterable<T>.modifiableForEach(action: (T) -> Unit) {
+    iterator().apply {
+        while (hasNext()) next().apply(action)
+    }
+}

--- a/core/src/main/java/io/plaidapp/core/util/Extensions.kt
+++ b/core/src/main/java/io/plaidapp/core/util/Extensions.kt
@@ -36,11 +36,10 @@ val <T> T.exhaustive: T
     get() = this
 
 /**
- * A for each loop where traversal is backed by an [Iterator] allowing for list modification
- * in place.
+ * A for each loop where traversal is backed by an [MutableIterator] allowing for removal
+ * during iteration.
  */
-inline fun <T> Iterable<T>.modifiableForEach(action: (T) -> Unit) {
-    iterator().apply {
-        while (hasNext()) next().apply(action)
-    }
+inline fun <T> MutableIterable<T>.removableForEach(action: (T) -> Unit) {
+    val iterator = iterator()
+    while (iterator.hasNext()) action(iterator.next())
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Added modifiableForEach extension method that allows for in place List modification during traversal.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Adresses #767 

If the SlideInItemAnimator is running during an orientation change, a `ConcurrentModificationException` will be thrown. This change allows for traversal with an iterator, allowing for in place modifications to the list.

## :green_heart: How did you test it?

I used the animator in another project where the SlideInItemAnimator runs continuously,  and triggered Activity destruction by rotating the phone. Source for that class is here: https://github.com/tunjid/android-bootstrap/blob/develop/app/src/main/java/com/tunjid/androidbootstrap/fragments/ShiftingTileFragment.kt

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
