### PR TITLE
Fixes sharedPreferences key not being written to

### DIFF
--- a/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSourceTest.kt
+++ b/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSourceTest.kt
@@ -63,5 +63,6 @@ class AuthTokenLocalDataSourceTest {
 
         // Then the auth token is also cleared
         assertNull(dataSource.authToken)
+        assertNull
     }
 }

--- a/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSourceTest.kt
+++ b/core/src/androidTest/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSourceTest.kt
@@ -63,6 +63,6 @@ class AuthTokenLocalDataSourceTest {
 
         // Then the auth token is also cleared
         assertNull(dataSource.authToken)
-        assertNull
+        assertNull(sharedPreferences.getString(AuthTokenLocalDataSource.KEY_ACCESS_TOKEN, null))
     }
 }

--- a/core/src/main/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSource.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSource.kt
@@ -36,7 +36,7 @@ class AuthTokenLocalDataSource(private val prefs: SharedPreferences) {
         }
 
     fun clearData() {
-        prefs.edit { KEY_ACCESS_TOKEN to null }
+        prefs.edit { putString(KEY_ACCESS_TOKEN, null) }
         authToken = null
     }
 

--- a/core/src/main/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSource.kt
+++ b/core/src/main/java/io/plaidapp/core/designernews/data/login/AuthTokenLocalDataSource.kt
@@ -42,7 +42,7 @@ class AuthTokenLocalDataSource(private val prefs: SharedPreferences) {
 
     companion object {
         const val DESIGNER_NEWS_AUTH_PREF = "DESIGNER_NEWS_AUTH_PREF"
-        private const val KEY_ACCESS_TOKEN = "KEY_ACCESS_TOKEN"
+        internal const val KEY_ACCESS_TOKEN = "KEY_ACCESS_TOKEN"
 
         @Volatile
         private var INSTANCE: AuthTokenLocalDataSource? = null


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix sharedPreferences key not being written to


## :bulb: Motivation and Context
The SharedPreferences were not properly cleared, and was not included in the tests.

## :green_heart: How did you test it?
I ran the unit tests to make sure it now works properly.

## :pencil: Checklist
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
