### PR TITLE
Centralize CoreComponent access method

### DIFF
--- a/app/src/main/java/io/plaidapp/dagger/Injector.kt
+++ b/app/src/main/java/io/plaidapp/dagger/Injector.kt
@@ -19,16 +19,16 @@
 package io.plaidapp.dagger
 
 import io.plaidapp.core.dagger.SharedPreferencesModule
+import io.plaidapp.core.dagger.coreComponent
 import io.plaidapp.core.designernews.data.login.LoginLocalDataSource
 import io.plaidapp.ui.HomeActivity
-import io.plaidapp.ui.coreComponent
 
 /**
  * Injector for HomeActivity.
  */
 fun inject(activity: HomeActivity) {
     DaggerHomeComponent.builder()
-        .coreComponent(activity.coreComponent())
+        .coreComponent(activity.coreComponent)
         .sharedPreferencesModule(
             SharedPreferencesModule(activity, LoginLocalDataSource.DESIGNER_NEWS_PREF)
         )

--- a/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
+++ b/app/src/main/java/io/plaidapp/ui/PlaidApplication.kt
@@ -16,20 +16,19 @@
 
 package io.plaidapp.ui
 
-import android.app.Activity
 import android.app.Application
-import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY
 import androidx.appcompat.app.AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 import androidx.appcompat.app.AppCompatDelegate.setDefaultNightMode
 import androidx.core.os.BuildCompat
 import io.plaidapp.core.dagger.CoreComponent
 import io.plaidapp.core.dagger.DaggerCoreComponent
+import io.plaidapp.core.dagger.HasCoreComponent
 
 /**
  * Io and Behold
  */
-class PlaidApplication : Application() {
+class PlaidApplication : Application(), HasCoreComponent {
 
     override fun onCreate() {
         super.onCreate()
@@ -41,15 +40,7 @@ class PlaidApplication : Application() {
         setDefaultNightMode(nightMode)
     }
 
-    private val coreComponent: CoreComponent by lazy {
+    override val coreComponent: CoreComponent by lazy(LazyThreadSafetyMode.NONE) {
         DaggerCoreComponent.create()
     }
-
-    companion object {
-        @JvmStatic
-        fun coreComponent(context: Context) =
-            (context.applicationContext as PlaidApplication).coreComponent
-    }
 }
-
-fun Activity.coreComponent() = PlaidApplication.coreComponent(this)

--- a/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/CoreComponent.kt
@@ -24,8 +24,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 /**
  * Component providing application wide singletons.
- * To call this make use of PlaidApplication.coreComponent or the
- * Activity.coreComponent extension function.
+ * Access [CoreComponent] via any [android.content.Context] instance
+ * using [io.plaidapp.core.dagger.HasCoreComponent.coreComponent]
  */
 @Component(modules = [CoreDataModule::class])
 @Singleton

--- a/core/src/main/java/io/plaidapp/core/dagger/HasCoreComponent.kt
+++ b/core/src/main/java/io/plaidapp/core/dagger/HasCoreComponent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC.
+ * Copyright 2020 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-package io.plaidapp.dribbble.dagger
+package io.plaidapp.core.dagger
 
-import io.plaidapp.core.dagger.coreComponent
-import io.plaidapp.dribbble.ui.shot.ShotActivity
+import android.content.Context
 
-/**
- * Inject dependencies into [ShotActivity]
- */
-fun ShotActivity.inject(shotId: Long) {
-    DaggerDribbbleComponent.builder()
-        .coreComponent(coreComponent)
-        .dribbbleModule(DribbbleModule(this, shotId))
-        .build()
-        .inject(this)
+interface HasCoreComponent {
+    val coreComponent: CoreComponent
 }
+
+val Context.coreComponent
+    get() = (this.applicationContext as HasCoreComponent).coreComponent

--- a/designernews/src/main/java/io/plaidapp/designernews/dagger/Injector.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/dagger/Injector.kt
@@ -21,11 +21,11 @@ package io.plaidapp.designernews.dagger
 import `in`.uncod.android.bypass.Bypass
 import android.util.TypedValue
 import io.plaidapp.core.dagger.MarkdownModule
+import io.plaidapp.core.dagger.coreComponent
 import io.plaidapp.core.util.ColorUtils
 import io.plaidapp.designernews.R
 import io.plaidapp.designernews.ui.login.LoginActivity
 import io.plaidapp.designernews.ui.story.StoryActivity
-import io.plaidapp.ui.coreComponent
 
 /**
  * Inject [StoryActivity].
@@ -46,7 +46,7 @@ fun inject(storyId: Long, activity: StoryActivity) {
         )
 
     DaggerStoryComponent.builder()
-        .coreComponent(activity.coreComponent())
+        .coreComponent(activity.coreComponent)
         .designerNewsModule(StoryModule(storyId, activity))
         .markdownModule(MarkdownModule(activity.resources.displayMetrics, bypassOptions))
         .sharedPreferencesModule(
@@ -59,7 +59,7 @@ fun inject(storyId: Long, activity: StoryActivity) {
 fun inject(activity: LoginActivity) {
 
     DaggerLoginComponent.builder()
-        .coreComponent(activity.coreComponent())
+        .coreComponent(activity.coreComponent)
         .sharedPreferencesModule(DesignerNewsPreferencesModule(activity))
         .build()
         .inject(activity)

--- a/designernews/src/main/java/io/plaidapp/designernews/domain/search/DesignerNewsSearchDataSourceFactoryProvider.kt
+++ b/designernews/src/main/java/io/plaidapp/designernews/domain/search/DesignerNewsSearchDataSourceFactoryProvider.kt
@@ -17,11 +17,11 @@
 package io.plaidapp.designernews.domain.search
 
 import android.content.Context
+import io.plaidapp.core.dagger.coreComponent
 import io.plaidapp.core.interfaces.SearchDataSourceFactory
 import io.plaidapp.core.interfaces.SearchDataSourceFactoryProvider
 import io.plaidapp.designernews.dagger.DaggerDesignerNewsSearchComponent
 import io.plaidapp.designernews.dagger.DesignerNewsPreferencesModule
-import io.plaidapp.ui.PlaidApplication.Companion.coreComponent
 
 /**
  * Provider for DesignerNews implementations of [SearchDataSourceFactory]
@@ -34,7 +34,7 @@ class DesignerNewsSearchDataSourceFactoryProvider : SearchDataSourceFactoryProvi
      */
     override fun getFactory(context: Context): SearchDataSourceFactory {
         return DaggerDesignerNewsSearchComponent.builder()
-            .coreComponent(coreComponent(context))
+            .coreComponent(context.coreComponent)
             .designerNewsPreferencesModule(
                 DesignerNewsPreferencesModule(context)
             )

--- a/dribbble/src/main/java/io/plaidapp/dribbble/domain/search/DribbbleSearchDataSourceFactoryProvider.kt
+++ b/dribbble/src/main/java/io/plaidapp/dribbble/domain/search/DribbbleSearchDataSourceFactoryProvider.kt
@@ -17,10 +17,10 @@
 package io.plaidapp.dribbble.domain.search
 
 import android.content.Context
+import io.plaidapp.core.dagger.coreComponent
 import io.plaidapp.core.interfaces.SearchDataSourceFactory
 import io.plaidapp.core.interfaces.SearchDataSourceFactoryProvider
 import io.plaidapp.dribbble.dagger.DaggerDribbbleSearchComponent
-import io.plaidapp.ui.PlaidApplication.Companion.coreComponent
 
 /**
  * Provider for Dribbble implementations of [SearchDataSourceFactory]
@@ -33,7 +33,7 @@ class DribbbleSearchDataSourceFactoryProvider : SearchDataSourceFactoryProvider 
      */
     override fun getFactory(context: Context): SearchDataSourceFactory {
         return DaggerDribbbleSearchComponent.builder()
-            .coreComponent(coreComponent(context))
+            .coreComponent(context.coreComponent)
             .build().factory()
     }
 }

--- a/search/src/main/java/io/plaidapp/search/dagger/Injector.kt
+++ b/search/src/main/java/io/plaidapp/search/dagger/Injector.kt
@@ -16,8 +16,8 @@
 
 package io.plaidapp.search.dagger
 
+import io.plaidapp.core.dagger.coreComponent
 import io.plaidapp.search.ui.SearchActivity
-import io.plaidapp.ui.coreComponent
 
 /**
  * Injector for SearchActivity.
@@ -29,7 +29,7 @@ object Injector {
     @JvmStatic
     fun inject(activity: SearchActivity) {
         DaggerSearchComponent.builder()
-            .coreComponent(activity.coreComponent())
+            .coreComponent(activity.coreComponent)
             .searchActivity(activity)
             .build()
             .inject(activity)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
We have several ways to access the CoreComponent, this PR centralize these methods into one.

## :green_heart: How did you test it?
Compile success + run the app where we access the CoreComponent

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing