### PR TITLE
Fixes android/plaid#616 : Removed Fabric and updated to Firebase Crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@
  */
 
 apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
@@ -81,7 +81,7 @@ android {
 dependencies {
     implementation project(':core')
     implementation "androidx.appcompat:appcompat:${versions.appcompat}"
-    implementation "com.crashlytics.sdk.android:crashlytics:${versions.crashlytics}"
+    implementation "com.google.firebase:firebase-crashlytics:${versions.crashlytics}"
     implementation "com.google.firebase:firebase-core:${versions.firebase}"
     implementation "com.github.bumptech.glide:glide:${versions.glide}"
     implementation "com.github.bumptech.glide:recyclerview-integration:${versions.glide}"

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,11 @@ buildscript { scriptHandler ->
             'constraintLayout'   : '2.0.0-alpha2',
             'coreKtx'            : '1.2.0-alpha03',
             'coroutines'         : '1.3.0',
-            'crashlytics'        : '2.10.1',
+            'crashlytics'        : '17.1.0',
+            'crashlytics_plugin' : '2.2.0',
             'dagger'             : '2.23.2',
             'espresso'           : '3.1.0-beta02',
             'extJunit'           : '1.1.0',
-            'fabric'             : '1.28.0',
             'firebase'           : '17.0.0',
             'glide'              : '4.9.0',
             'googleServices'     : '4.3.0',
@@ -63,7 +63,7 @@ buildscript { scriptHandler ->
         classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "com.google.gms:google-services:${versions.googleServices}"
-        classpath "io.fabric.tools:gradle:${versions.fabric}"
+        classpath "com.google.firebase:firebase-crashlytics-gradle:${versions.crashlytics_plugin}"
     }
 }
 

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -7,6 +7,7 @@ repositories {
             includeGroup "android.arch.lifecycle"
             includeGroup "android.arch.core"
             includeGroup "com.google.firebase"
+            includeGroup "com.google.android.datatransport"
             includeGroup "com.google.android.gms"
             includeGroup "com.google.android.material"
             includeGroup "com.google.gms"
@@ -57,14 +58,6 @@ repositories {
             excludeGroup "com.google.firebase"
             excludeGroup "com.google.android.gms"
             excludeGroup "com.google.android.material"
-        }
-    }
-
-    maven {
-        url 'https://maven.fabric.io/public'
-        content {
-            includeGroupByRegex "io\\.fabric.*"
-            includeGroupByRegex "com\\.crashlytics.*"
         }
     }
 


### PR DESCRIPTION
##  :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Removed references to fabric  crashlytics and replaced with Firebase Crashlytics.

- Separate versions for the gradle plugin (`crashlytics_plugin`) and the library dependency (`crashlytics`)
- Added maven dependency group for `com.google.android.datatransport`, which is a transient dependency of Firebase Crashlytics


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fabric's Crashlytics is deprecated in favor of Firebase Crashlytics.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes this open issue: https://github.com/android/plaid/issues/616


## :green_heart: How did you test it?
Manually by building and running the app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
Integrate this PR :)

## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
