### PR TITLE
Fix #842

### DIFF
--- a/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
+++ b/core/src/main/java/io/plaidapp/core/ui/recyclerview/SlideInItemAnimator.kt
@@ -26,6 +26,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.RecyclerView
 import io.plaidapp.core.util.listenForAllSpringsEnd
 import io.plaidapp.core.util.spring
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * A [RecyclerView.ItemAnimator] that fades & slides newly added items in from a given
@@ -37,10 +38,10 @@ open class SlideInItemAnimator @JvmOverloads constructor(
 ) : DefaultItemAnimator() {
 
     private val slideFromEdge: Int = Gravity.getAbsoluteGravity(slideFromEdge, layoutDirection)
-    private val pendingAdds = mutableListOf<RecyclerView.ViewHolder>()
-    private val runningAdds = mutableListOf<RecyclerView.ViewHolder>()
-    private val pendingMoves = mutableListOf<RecyclerView.ViewHolder>()
-    private val runningMoves = mutableListOf<RecyclerView.ViewHolder>()
+    private val pendingAdds = CopyOnWriteArrayList<RecyclerView.ViewHolder>()
+    private val runningAdds = CopyOnWriteArrayList<RecyclerView.ViewHolder>()
+    private val pendingMoves = CopyOnWriteArrayList<RecyclerView.ViewHolder>()
+    private val runningMoves = CopyOnWriteArrayList<RecyclerView.ViewHolder>()
 
     @SuppressLint("RtlHardcoded")
     override fun animateAdd(holder: RecyclerView.ViewHolder): Boolean {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Changed `MutableList` to `CopyOnWriteArrayList ` to prevent `ConcurrentModificationException`


## :bulb: Motivation and Context
I took this class as reference to create an animation to my lists, I had this problem and I wanted to help other people out if they are deciding to use this class in their apps


## :green_heart: How did you test it?
I had a case in this gif in the issue #842 and now it doesn't happen

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing

## :camera_flash: Screenshots / GIFs
Look at #842
