### PR TITLE
Fix: multi-window mode insets problems (#236)

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -15,83 +15,100 @@
   limitations under the License.
   -->
 
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/drawer"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:clipToPadding="false"
-    tools:context=".ui.HomeActivity">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <FrameLayout
+    <androidx.drawerlayout.widget.DrawerLayout
+        android:id="@+id/drawer"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <View
-            android:id="@+id/status_bar_background"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="@color/status_bar_back" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/grid"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:elevation="1dp"
-            android:scrollbarStyle="outsideOverlay"
-            android:scrollbars="vertical" />
-
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            style="@style/Widget.Plaid.HomeToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?android:actionBarSize"
-            android:elevation="1dp"
-            android:outlineProvider="none"
-            android:title="@string/app_name" />
-
-        <ProgressBar
-            android:id="@android:id/empty"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:indeterminate="true"
-            android:indeterminateTint="?android:colorAccent"
-            android:indeterminateTintMode="src_in" />
-
-        <ViewStub
-            android:id="@+id/stub_no_filters"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_margin="@dimen/spacing_huge"
-            android:layout="@layout/no_filters" />
-
-        <ViewStub
-            android:id="@+id/stub_no_connection"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout="@layout/no_connection" />
-
-    </FrameLayout>
-
-    <!-- filter drawer -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/filters"
-        android:layout_width="@dimen/drawer_width"
         android:layout_height="match_parent"
-        android:layout_gravity="end"
-        android:background="@color/background_dark"
         android:clipToPadding="false"
-        android:elevation="@dimen/z_drawer"
-        android:paddingTop="@dimen/spacing_normal"
-        android:paddingBottom="@dimen/spacing_normal"
-        android:scrollbarStyle="outsideOverlay"
-        android:scrollbars="vertical"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        tools:listitem="@layout/filter_item" />
+        tools:context=".ui.HomeActivity">
 
-</androidx.drawerlayout.widget.DrawerLayout>
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <View
+                android:id="@+id/status_bar_background"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:background="@color/status_bar_back" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/grid"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:elevation="1dp"
+                android:paddingTop="?android:actionBarSize"
+                android:scrollbarStyle="outsideOverlay"
+                android:scrollbars="vertical"
+                app:paddingTopSystemWindowInsets="@{true}"
+                app:paddingBottomSystemWindowInsets="@{true}"
+                app:paddingLeftSystemWindowInsets="@{true}"
+                app:paddingRightSystemWindowInsets="@{true}" />
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                style="@style/Widget.Plaid.HomeToolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?android:actionBarSize"
+                android:elevation="1dp"
+                android:outlineProvider="none"
+                android:title="@string/app_name"
+                app:marginTopSystemWindowInsets="@{true}"
+                app:marginBottomSystemWindowInsets="@{true}"
+                app:marginLeftSystemWindowInsets="@{true}"
+                app:marginRightSystemWindowInsets="@{true}" />
+
+            <ProgressBar
+                android:id="@android:id/empty"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminate="true"
+                android:indeterminateTint="?android:colorAccent"
+                android:indeterminateTintMode="src_in" />
+
+            <ViewStub
+                android:id="@+id/stub_no_filters"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="@dimen/spacing_huge"
+                android:layout="@layout/no_filters" />
+
+            <ViewStub
+                android:id="@+id/stub_no_connection"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout="@layout/no_connection" />
+
+        </FrameLayout>
+
+        <!-- filter drawer -->
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/filters"
+            android:layout_width="@dimen/drawer_width"
+            android:layout_height="match_parent"
+            android:layout_gravity="end"
+            android:background="@color/background_dark"
+            android:clipToPadding="false"
+            android:elevation="@dimen/z_drawer"
+            android:paddingTop="@dimen/spacing_normal"
+            android:paddingBottom="@dimen/spacing_normal"
+            android:scrollbarStyle="outsideOverlay"
+            android:scrollbars="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:paddingTopSystemWindowInsets="@{true}"
+            app:paddingBottomSystemWindowInsets="@{true}"
+            app:paddingLeftSystemWindowInsets="@{true}"
+            app:paddingRightSystemWindowInsets="@{true}"
+            tools:listitem="@layout/filter_item" />
+
+    </androidx.drawerlayout.widget.DrawerLayout>
+
+</layout>


### PR DESCRIPTION
Takes care of few WindowInsets problems with HomeActivity layout:

-  toolbar not being correctly padded when returning from multi-window mode (bottom position)
- toolbar not being correctly laid out when back to multi-window after activity was “hidden” with second activity

Resolves: #236

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I ran `./gradlew spotlessApply` before submitting the PR
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->
